### PR TITLE
feat(login): allow skipping OTP when MFA_TOTP_SECRET is not configured

### DIFF
--- a/app/login/login-form.tsx
+++ b/app/login/login-form.tsx
@@ -10,7 +10,11 @@ import { Label } from "@/components/ui/label";
 
 const initialState = { error: null as string | null };
 
-export function LoginForm() {
+type LoginFormProps = {
+  mfaEnabled?: boolean;
+};
+
+export function LoginForm({ mfaEnabled = false }: LoginFormProps) {
   const [state, formAction, pending] = useActionState(loginAction, initialState);
 
   return (
@@ -25,18 +29,20 @@ export function LoginForm() {
             <Label htmlFor="password">パスワード</Label>
             <Input id="password" name="password" type="password" required />
           </div>
-          <div className="space-y-2">
-            <Label htmlFor="otp">ワンタイムパスワード</Label>
-            <Input
-              id="otp"
-              name="otp"
-              type="text"
-              inputMode="numeric"
-              pattern="[0-9]{6}"
-              placeholder="6桁コード（2要素認証有効時は必須）"
-              autoComplete="one-time-code"
-            />
-          </div>
+          {mfaEnabled ? (
+            <div className="space-y-2">
+              <Label htmlFor="otp">ワンタイムパスワード</Label>
+              <Input
+                id="otp"
+                name="otp"
+                type="text"
+                inputMode="numeric"
+                pattern="[0-9]{6}"
+                placeholder="6桁コード（2要素認証有効時は必須）"
+                autoComplete="one-time-code"
+              />
+            </div>
+          ) : null}
           {state.error ? (
             <p className="text-sm font-medium text-destructive">{state.error}</p>
           ) : null}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,9 +1,12 @@
 import { LoginForm } from "./login-form";
 
 export default function LoginPage() {
+  const totpSecret = (process.env.MFA_TOTP_SECRET ?? "").trim();
+  const mfaEnabled = totpSecret.length > 0;
+
   return (
     <main className="flex min-h-screen items-center justify-center px-4 py-10">
-      <LoginForm />
+      <LoginForm mfaEnabled={mfaEnabled} />
     </main>
   );
 }


### PR DESCRIPTION
概要:
- 環境変数 `MFA_TOTP_SECRET` が設定されていない場合、ログイン画面で OTP 入力欄を表示せず、OTP をスキップしてログインできるようにしました。

実装内容:
- `app/login/page.tsx`: サーバー環境変数を読み `mfaEnabled` を `LoginForm` に渡す。
- `app/login/login-form.tsx`: `mfaEnabled` が false の場合は OTP 入力欄を表示しない。

テスト/確認:
- ローカルで `npm run build` を実行しビルド成功を確認済み。

備考:
- `MFA_TOTP_SECRET` を設定した環境では従来通り OTP が必須です。

Fixes #22