### PR TITLE
ci: use Preview environment for migrate-staging

### DIFF
--- a/.github/workflows/migrate-staging.yml
+++ b/.github/workflows/migrate-staging.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   migrate-staging:
     runs-on: ubuntu-latest
+    environment: "Preview – mj-score-manager-tfvp"
     env:
       PREVIEW_DATABASE_URL: ${{ secrets.PREVIEW_DATABASE_URL }}
       STAGING_DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}


### PR DESCRIPTION
Use the 'Preview – mj-score-manager-tfvp' environment for the migrate-staging job so environment secrets (STAGING_DATABASE_URL etc.) are available to the workflow. This is a small CI workflow change; please review and merge to enable running migrations against the environment-managed DB.