### PR TITLE
ci: use Preview environment for debug connectivity

### DIFF
--- a/.github/workflows/debug-connectivity.yml
+++ b/.github/workflows/debug-connectivity.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   debug-connectivity:
     runs-on: ubuntu-latest
+    environment: "Preview – mj-score-manager-tfvp"
     env:
       PREVIEW_DATABASE_URL: ${{ secrets.PREVIEW_DATABASE_URL }}
       STAGING_DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}


### PR DESCRIPTION
Make the debug-connectivity job use the Preview – mj-score-manager-tfvp environment so environment secrets (STAGING_DATABASE_URL) are available to the runner. Please merge to run diagnostics.