### PR TITLE
fix: #30 #53 日付フィルタ挙動と役満編集確定タイミングを修正

### DIFF
--- a/app/match-actions.ts
+++ b/app/match-actions.ts
@@ -77,6 +77,43 @@ function parseScore(value: FormDataEntryValue | null) {
   return parsed;
 }
 
+type YakumanSelection = {
+  playerName: string;
+  yakumanCode: string;
+  yakumanName: string;
+  points: number | null;
+};
+
+function parseYakumanSelections(value: FormDataEntryValue | null): YakumanSelection[] {
+  const raw = String(value ?? "").trim();
+  if (!raw) return [];
+
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+
+    return parsed
+      .map((item) => {
+        const row = item as Record<string, unknown>;
+        const playerName = String(row.playerName ?? "").trim();
+        const yakumanCode = String(row.yakumanCode ?? "").trim();
+        const yakumanName = String(row.yakumanName ?? "").trim();
+        const pointsRaw = row.points;
+
+        let points: number | null = null;
+        if (pointsRaw !== null && pointsRaw !== undefined && String(pointsRaw).trim() !== "") {
+          const parsedPoints = Number(pointsRaw);
+          points = Number.isFinite(parsedPoints) ? parsedPoints : null;
+        }
+
+        return { playerName, yakumanCode, yakumanName, points };
+      })
+      .filter((item) => item.playerName && item.yakumanCode && item.yakumanName);
+  } catch {
+    return [];
+  }
+}
+
 function validatePlayer(name: string, label: string) {
   if (!name) {
     return `${label}を選択してください`;
@@ -219,6 +256,7 @@ export async function editMatchAction(
   const lastPlayer = rankedEntries[rankedEntries.length - 1]?.player ?? "";
 
   const notes = parseString(formData.get("notes"));
+  const yakumanSelections = parseYakumanSelections(formData.get("yakumanSelections"));
 
   const supabaseUrl = process.env.SUPABASE_URL;
   const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
@@ -267,6 +305,62 @@ export async function editMatchAction(
     if (error) {
       console.error("Edit match error:", error);
       return { success: false, message: "対局の編集に失敗しました。" };
+    }
+
+    const { data: gameRows, error: gameIdError } = await supabase
+      .from("games")
+      .select("id")
+      .eq("created_at", createdAt)
+      .limit(1);
+
+    if (gameIdError) {
+      console.error("Edit match yakuman game lookup error:", gameIdError);
+      return { success: false, message: "役満情報の保存に失敗しました。" };
+    }
+
+    const gameId = gameRows && gameRows.length > 0 ? Number(gameRows[0].id) : null;
+    if (!gameId) {
+      return { success: false, message: "役満情報の保存に失敗しました。" };
+    }
+
+    const playerRows = await supabase.from("players").select("id,name").in("name", players);
+    if (playerRows.error || !playerRows.data) {
+      console.error("Edit match yakuman player lookup error:", playerRows.error);
+      return { success: false, message: "役満情報の保存に失敗しました。" };
+    }
+
+    const playerIdByName = new Map(
+      playerRows.data.map((row) => [String(row.name), Number(row.id)])
+    );
+
+    const deleteYakumanRes = await supabase.from("yakuman_occurrences").delete().eq("game_id", gameId);
+    if (deleteYakumanRes.error) {
+      console.error("Edit match yakuman delete error:", deleteYakumanRes.error);
+      return { success: false, message: "役満情報の保存に失敗しました。" };
+    }
+
+    if (yakumanSelections.length > 0) {
+      const insertRows = yakumanSelections
+        .map((selection) => {
+          const playerId = playerIdByName.get(selection.playerName);
+          if (!playerId) return null;
+          return {
+            game_id: gameId,
+            player_id: playerId,
+            yakuman_code: selection.yakumanCode,
+            yakuman_name: selection.yakumanName,
+            points: selection.points,
+          };
+        })
+        .filter((row): row is { game_id: number; player_id: number; yakuman_code: string; yakuman_name: string; points: number | null } => row !== null);
+
+      if (insertRows.length > 0) {
+        const insertYakumanRes = await supabase.from("yakuman_occurrences").insert(insertRows);
+        if (insertYakumanRes.error) {
+          console.error("Edit match yakuman insert error:", insertYakumanRes.error);
+          return { success: false, message: "役満情報の保存に失敗しました。" };
+        }
+      }
     }
 
     return { success: true, message: "対局を編集しました。" };

--- a/app/matches/page.tsx
+++ b/app/matches/page.tsx
@@ -133,7 +133,7 @@ export default async function MatchesPage({ searchParams }: { searchParams?: Pro
                               {player.yakumans && player.yakumans.length > 0 ? (
                                 <p className="mt-2">
                                   <span className="inline-flex rounded border border-sky-200 bg-sky-50 px-2 py-0.5 text-xs font-semibold text-sky-900">
-                                    役満: {player.yakumans.map((y) => y.name).join("、")}
+                                    {player.yakumans.map((y) => y.name).join("、")}
                                   </span>
                                 </p>
                               ) : null}
@@ -214,7 +214,7 @@ export default async function MatchesPage({ searchParams }: { searchParams?: Pro
                                   ) : null}
                                   {player.yakumans && player.yakumans.length > 0 ? (
                                     <span className="ml-2 rounded border border-sky-200 bg-sky-50 px-1.5 py-0.5 text-[11px] font-semibold text-sky-900">
-                                      役満: {player.yakumans.map((y) => y.name).join("、")}
+                                      {player.yakumans.map((y) => y.name).join("、")}
                                     </span>
                                   ) : null}
                                 </li>

--- a/components/date-range-filter.tsx
+++ b/components/date-range-filter.tsx
@@ -43,6 +43,9 @@ export default function DateRangeFilter({ initialStart, initialEnd, initialToday
   }
 
   function handleStartChange(value: string) {
+    if (todayChecked) {
+      setTodayChecked(false);
+    }
     setStart(value);
     if (end && value && value > end) {
       // invalid: start after end -> clear start and show flash
@@ -52,6 +55,9 @@ export default function DateRangeFilter({ initialStart, initialEnd, initialToday
   }
 
   function handleEndChange(value: string) {
+    if (todayChecked) {
+      setTodayChecked(false);
+    }
     setEnd(value);
     if (start && value && start > value) {
       // invalid: end before start -> clear end and show flash

--- a/components/match-edit-form.tsx
+++ b/components/match-edit-form.tsx
@@ -4,7 +4,6 @@ import { useActionState, useEffect, useMemo, useState, useTransition } from "rea
 import { useRouter } from "next/navigation";
 
 import { editMatchAction, type EditMatchState } from "@/app/match-actions";
-import { addYakumanAction, type YakumanActionState } from "@/app/yakuman-actions";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -13,7 +12,6 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { PlayerSelect } from "@/components/ui/player-select";
 import type { MatchResult } from "@/lib/matches";
 import YAKUMANS from "@/lib/yakumans";
-import { deleteYakumanAction } from "@/app/yakuman-actions";
 
 const initialState: EditMatchState = {
   success: false,
@@ -81,12 +79,7 @@ export function MatchEditForm({ match, players: playerList, createdAt, yakumans 
   const [yakumanCodeBySlot, setYakumanCodeBySlot] = useState<Record<number, string>>({ 1: "", 2: "", 3: "", 4: "" });
   const [yakumanNameBySlot, setYakumanNameBySlot] = useState<Record<number, string>>({ 1: "", 2: "", 3: "", 4: "" });
   const [yakumanPointsBySlot, setYakumanPointsBySlot] = useState<Record<number, string>>({ 1: "", 2: "", 3: "", 4: "" });
-  const [yakumanState, yakumanAction] = useActionState(addYakumanAction, { success: false, message: "" } as YakumanActionState);
-  const [deleteState, deleteAction] = useActionState(deleteYakumanAction, { success: false, message: "" } as YakumanActionState);
   const [displayYakumans, setDisplayYakumans] = useState<YakumanOccurrence[]>(yakumans ?? []);
-  const [lastAddedYakuman, setLastAddedYakuman] = useState<YakumanOccurrence | null>(null);
-  const [yakumanMessageSlot, setYakumanMessageSlot] = useState<number | null>(null);
-  const [deletingYakumanId, setDeletingYakumanId] = useState<number | null>(null);
 
   const activeSlots = useMemo(() => (gameType === "4p" ? [1, 2, 3, 4] : [1, 2, 3]), [gameType]);
 
@@ -148,35 +141,6 @@ export function MatchEditForm({ match, players: playerList, createdAt, yakumans 
   }, [yakumans]);
 
   useEffect(() => {
-    if (yakumanState.success && lastAddedYakuman) {
-      setDisplayYakumans((current) => [...current, lastAddedYakuman]);
-      setLastAddedYakuman(null);
-      router.refresh();
-    }
-  }, [yakumanState.success, lastAddedYakuman, router]);
-
-  useEffect(() => {
-    if (!yakumanState.success && yakumanState.message) {
-      setLastAddedYakuman(null);
-    }
-  }, [yakumanState.success, yakumanState.message]);
-
-  useEffect(() => {
-    if (deleteState.success && deletingYakumanId !== null) {
-      setDisplayYakumans((current) => current.filter((y) => y.id !== deletingYakumanId));
-      setDeletingYakumanId(null);
-      router.refresh();
-      window.dispatchEvent(new CustomEvent("app:flash", { detail: { type: "yakumanDeleted" } }));
-    }
-  }, [deleteState.success, deletingYakumanId, router]);
-
-  useEffect(() => {
-    if (!deleteState.success && deleteState.message) {
-      setDeletingYakumanId(null);
-    }
-  }, [deleteState.success, deleteState.message]);
-
-  useEffect(() => {
     const scoreCount = gameType === "4p" ? 4 : 3;
     const playerScores: Record<string, string> = Object.fromEntries(
       new Array(scoreCount)
@@ -232,6 +196,19 @@ export function MatchEditForm({ match, players: playerList, createdAt, yakumans 
     form.append("tobiPlayer", tobiPlayer === NONE_VALUE ? "" : tobiPlayer);
     form.append("tobashiPlayer", tobashiPlayer === NONE_VALUE ? "" : tobashiPlayer);
     form.append("notes", notes);
+
+    const activePlayerNames = new Set(
+      activeSlots.map((slot) => players[slot as keyof PlayerSelection]).filter(Boolean)
+    );
+    const yakumanSelections = displayYakumans
+      .filter((y) => activePlayerNames.has(y.player_name))
+      .map((y) => ({
+        playerName: y.player_name,
+        yakumanCode: y.yakuman_code,
+        yakumanName: y.yakuman_name,
+        points: y.points,
+      }));
+    form.append("yakumanSelections", JSON.stringify(yakumanSelections));
     return form;
   };
 
@@ -391,35 +368,31 @@ export function MatchEditForm({ match, players: playerList, createdAt, yakumans 
                       setClientError("プレイヤーを選択してください。役満を追加できません。");
                       return;
                     }
-                    const form = new FormData();
-                    form.append("createdAt", createdAt);
-                    form.append("playerName", playerName);
-                    form.append("yakumanCode", yakumanCodeBySlot[slot] ?? "");
-                    form.append("yakumanName", yakumanNameBySlot[slot] ?? "");
-                    form.append("points", yakumanPointsBySlot[slot] ?? "");
-                    setYakumanMessageSlot(slot);
-                    setLastAddedYakuman({
+                    const yakumanCode = yakumanCodeBySlot[slot] ?? "";
+                    const yakumanName = yakumanNameBySlot[slot] ?? "";
+                    if (!yakumanCode || !yakumanName) {
+                      setClientError("役満を選択してください。");
+                      return;
+                    }
+
+                    setDisplayYakumans((current) => [...current, {
                       id: -Date.now(),
                       player_id: 0,
                       player_name: playerName,
-                      yakuman_code: yakumanCodeBySlot[slot] ?? "",
-                      yakuman_name: yakumanNameBySlot[slot] ?? "",
+                      yakuman_code: yakumanCode,
+                      yakuman_name: yakumanName,
                       points: yakumanPointsBySlot[slot] ? Number(yakumanPointsBySlot[slot]) : null,
                       created_at: new Date().toISOString(),
-                    });
-                    startTransition(() => {
-                      // call server action to add yakuman
-                      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                      // @ts-ignore
-                      yakumanAction(form);
-                    });
+                    }]);
+
+                    setYakumanCodeBySlot((p) => ({ ...p, [slot]: "" }));
+                    setYakumanNameBySlot((p) => ({ ...p, [slot]: "" }));
+                    setYakumanPointsBySlot((p) => ({ ...p, [slot]: "" }));
                   }}
                 >
                   役満を追加
                 </Button>
-                {yakumanState?.message && yakumanMessageSlot === slot ? (
-                  <div className="mt-2 text-sm text-emerald-800">{yakumanState.message}</div>
-                ) : null}
+                <div className="mt-2 text-xs text-emerald-800">※ 役満の追加・削除は「対局を編集」で確定します。</div>
               </div>
             </div>
             {/* existing yakumans for this match (if any) - show only those for this slot, display code only */}
@@ -444,14 +417,7 @@ export function MatchEditForm({ match, players: playerList, createdAt, yakumans 
                               size="sm"
                               variant="destructive"
                               onClick={() => {
-                                setDeletingYakumanId(y.id);
-                                const form = new FormData();
-                                form.append("id", String(y.id));
-                                startTransition(() => {
-                                  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                                  // @ts-ignore
-                                  deleteAction(form);
-                                });
+                                setDisplayYakumans((current) => current.filter((row) => row.id !== y.id));
                               }}
                             >
                               削除


### PR DESCRIPTION
## 概要
Issue #30, #53 の対応を実施しました。あわせて対局履歴の役満表示文言を調整しています。

## 変更内容
- #30: 当日チェック有効時に開始日/終了日を手入力したら当日チェックを自動解除
- #53: 対局履歴編集画面の役満追加/削除はローカル反映に変更し、`対局を編集`押下時に一括確定
- matches一覧の役満表示から `役満:` プレフィックスを削除

## 影響ファイル
- app/match-actions.ts
- components/match-edit-form.tsx
- components/date-range-filter.tsx
- app/matches/page.tsx

## 検証
- npm run build: 成功

Closes #30
Closes #53