### PR TITLE
feat(issue-57): games にプレイヤー参照 ID 列を追加し名前スナップショットを併存

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -197,6 +197,26 @@ export async function saveScoreAction(
   const supabase = createClient(supabaseUrl, supabaseKey, { auth: { persistSession: false } });
 
   try {
+    // プレイヤー名から players.id を一括解決する
+    const allNames = Array.from(new Set([
+      ...players,
+      ...(tobiPlayer ? [tobiPlayer] : []),
+      ...(tobashiPlayer ? [tobashiPlayer] : []),
+      ...[...yakitoriPlayers],
+    ]));
+    const { data: playerRows, error: playerResolveErr } = await supabase
+      .from("players")
+      .select("id,name")
+      .in("name", allNames);
+    if (playerResolveErr) {
+      console.error("Player resolve error:", playerResolveErr);
+      return { success: false, message: "プレイヤー情報の取得に失敗しました。" };
+    }
+    const nameToId = new Map<string, number>();
+    for (const r of (playerRows ?? []) as Array<{ id: number; name: string }>) {
+      nameToId.set(r.name, r.id);
+    }
+
     type RowValue = string | number | boolean | null;
 
     const row: Record<string, RowValue> = {
@@ -205,16 +225,24 @@ export async function saveScoreAction(
       player_count: players.length,
       score_total: total,
       top_player: topPlayer,
+      top_player_id: nameToId.get(topPlayer) ?? null,
       last_player: lastPlayer,
+      last_player_id: nameToId.get(lastPlayer) ?? null,
       tobi_player: tobiPlayer ?? null,
+      tobi_player_id: tobiPlayer ? (nameToId.get(tobiPlayer) ?? null) : null,
       tobashi_player: tobashiPlayer ?? null,
+      tobashi_player_id: tobashiPlayer ? (nameToId.get(tobashiPlayer) ?? null) : null,
       yakitori_players: [...yakitoriPlayers].join(","),
+      yakitori_player_ids: JSON.stringify(
+        [...yakitoriPlayers].map((n) => nameToId.get(n)).filter((id): id is number => id !== undefined)
+      ),
       notes,
       created_at: new Date().toISOString(),
     };
 
     for (const entry of entries) {
       row[`player${entry.slot}`] = entry.player;
+      row[`player${entry.slot}_id`] = nameToId.get(entry.player) ?? null;
       row[`score${entry.slot}`] = entry.score;
       row[`rank${entry.slot}`] = entry.rank;
       row[`is_tobi${entry.slot}`] = entry.isTobi;
@@ -224,6 +252,7 @@ export async function saveScoreAction(
 
     if (gameType === "3p") {
       row.player4 = null;
+      row.player4_id = null;
       row.score4 = null;
       row.rank4 = null;
       row.is_tobi4 = false;

--- a/app/api/export/games/csv-builder.d.ts
+++ b/app/api/export/games/csv-builder.d.ts
@@ -1,5 +1,5 @@
 interface MatchPlayer {
-  id?: string;
+  id?: number | null;
   name?: string;
   slot?: number;
   score?: number;
@@ -11,6 +11,11 @@ interface MatchRow {
   playerCount?: number;
   players?: MatchPlayer[];
   notes?: string;
+  topPlayerId?: number | null;
+  lastPlayerId?: number | null;
+  tobiPlayerId?: number | null;
+  tobashiPlayerId?: number | null;
+  yakitoriPlayerIds?: number[];
 }
 
 export function buildGamesCsv(matches: MatchRow[], opts?: { start?: string; end?: string }): { csv: string; filename: string };

--- a/app/api/export/games/csv-builder.js
+++ b/app/api/export/games/csv-builder.js
@@ -79,8 +79,12 @@ export function buildGamesCsv(matches, opts = {}) {
     }
 
     const metadata = {
-      source: "sheets",
-      sheet: process.env.GOOGLE_SHEET_TITLE ?? null,
+      source: "supabase",
+      top_player_id: m.topPlayerId ?? null,
+      last_player_id: m.lastPlayerId ?? null,
+      tobi_player_id: m.tobiPlayerId ?? null,
+      tobashi_player_id: m.tobashiPlayerId ?? null,
+      yakitori_player_ids: m.yakitoriPlayerIds ?? [],
     };
 
     const tail = [escapeCsv(m.notes ?? ""), escapeCsv(JSON.stringify(metadata)), escapeCsv("v1")];

--- a/app/api/export/games/handler.d.ts
+++ b/app/api/export/games/handler.d.ts
@@ -1,5 +1,5 @@
 interface MatchPlayer {
-  id?: string;
+  id?: number | null;
   name?: string;
   slot?: number;
   score?: number;
@@ -11,6 +11,11 @@ interface MatchRow {
   playerCount?: number;
   players?: MatchPlayer[];
   notes?: string;
+  topPlayerId?: number | null;
+  lastPlayerId?: number | null;
+  tobiPlayerId?: number | null;
+  tobashiPlayerId?: number | null;
+  yakitoriPlayerIds?: number[];
 }
 
 export function makeGamesResponse(matches: MatchRow[], opts?: { start?: string; end?: string }): { csv: string; filename: string; headers: Record<string, string> };

--- a/app/match-actions.ts
+++ b/app/match-actions.ts
@@ -268,6 +268,26 @@ export async function editMatchAction(
   const supabase = createClient(supabaseUrl, supabaseKey, { auth: { persistSession: false } });
 
   try {
+    // プレイヤー名から players.id を一括解決する
+    const allNames = Array.from(new Set([
+      ...players,
+      ...(tobiPlayer ? [tobiPlayer] : []),
+      ...(tobashiPlayer ? [tobashiPlayer] : []),
+      ...[...yakitoriPlayers],
+    ]));
+    const { data: playerRows, error: playerResolveErr } = await supabase
+      .from("players")
+      .select("id,name")
+      .in("name", allNames);
+    if (playerResolveErr) {
+      console.error("Player resolve error:", playerResolveErr);
+      return { success: false, message: "プレイヤー情報の取得に失敗しました。" };
+    }
+    const nameToId = new Map<string, number>();
+    for (const r of (playerRows ?? []) as Array<{ id: number; name: string }>) {
+      nameToId.set(r.name, r.id);
+    }
+
     type RowValue = string | number | boolean | null;
 
     const updatePayload: Record<string, RowValue> = {
@@ -276,15 +296,23 @@ export async function editMatchAction(
       player_count: players.length,
       score_total: total,
       top_player: topPlayer,
+      top_player_id: nameToId.get(topPlayer) ?? null,
       last_player: lastPlayer,
+      last_player_id: nameToId.get(lastPlayer) ?? null,
       tobi_player: tobiPlayer ?? null,
+      tobi_player_id: tobiPlayer ? (nameToId.get(tobiPlayer) ?? null) : null,
       tobashi_player: tobashiPlayer ?? null,
+      tobashi_player_id: tobashiPlayer ? (nameToId.get(tobashiPlayer) ?? null) : null,
       yakitori_players: [...yakitoriPlayers].join(","),
+      yakitori_player_ids: JSON.stringify(
+        [...yakitoriPlayers].map((n) => nameToId.get(n)).filter((id): id is number => id !== undefined)
+      ),
       notes,
     };
 
     for (const entry of entries) {
       updatePayload[`player${entry.slot}`] = entry.player;
+      updatePayload[`player${entry.slot}_id`] = nameToId.get(entry.player) ?? null;
       updatePayload[`score${entry.slot}`] = entry.score;
       updatePayload[`rank${entry.slot}`] = entry.rank;
       updatePayload[`is_tobi${entry.slot}`] = entry.isTobi;
@@ -294,6 +322,7 @@ export async function editMatchAction(
 
     if (gameType === "3p") {
       updatePayload.player4 = null;
+      updatePayload.player4_id = null;
       updatePayload.score4 = null;
       updatePayload.rank4 = null;
       updatePayload.is_tobi4 = false;
@@ -323,14 +352,14 @@ export async function editMatchAction(
       return { success: false, message: "役満情報の保存に失敗しました。" };
     }
 
-    const playerRows = await supabase.from("players").select("id,name").in("name", players);
-    if (playerRows.error || !playerRows.data) {
-      console.error("Edit match yakuman player lookup error:", playerRows.error);
+    const yakumanPlayerRows = await supabase.from("players").select("id,name").in("name", players);
+    if (yakumanPlayerRows.error || !yakumanPlayerRows.data) {
+      console.error("Edit match yakuman player lookup error:", yakumanPlayerRows.error);
       return { success: false, message: "役満情報の保存に失敗しました。" };
     }
 
     const playerIdByName = new Map(
-      playerRows.data.map((row) => [String(row.name), Number(row.id)])
+      yakumanPlayerRows.data.map((row) => [String(row.name), Number(row.id)])
     );
 
     const deleteYakumanRes = await supabase.from("yakuman_occurrences").delete().eq("game_id", gameId);

--- a/design/adr/0006-games-player-ids.md
+++ b/design/adr/0006-games-player-ids.md
@@ -1,0 +1,129 @@
+# ADR 0006: games にプレイヤー参照 ID を導入し、表示用プレイヤー名を併存させる
+
+日付: 2026-04-03
+ステータス: accepted
+作成者: プロジェクト（個人開発）
+
+## 背景
+
+`games` テーブルは player1..player4、top_player、last_player、tobi_player、tobashi_player、yakitori_players を
+プレイヤー名文字列で保持している（`supabase/migrations/20260401000001_create_games.sql`）。
+
+この構造では `players` テーブルとの参照整合性が弱く、次の問題がある。
+
+- プレイヤー名変更時に履歴・集計・CSV の整合が崩れやすい。
+- 集計クエリや JOIN がプレイヤー名文字列の完全一致前提になる。
+- 役満記録（`yakuman_occurrences`）は `players.id` を外部キーとして持つが、`games` 本体は名前文字列のみのため参照が非対称。
+
+Issue #57 の最低要件は「games に player.id を格納しつつプレイヤー名も残す」こと。
+
+## 決定
+
+1. `games` の既存 player 名列は対局時点のスナップショットとして**残す**（非破壊移行）。
+2. 参照整合性用の player ID 列を新たに追加する。
+3. 参加者列（player1_id..player4_id）に加え、派生参照列（top/last/tobi/tobashi）も ID 列を持つ。
+4. yakitori は複数人を取りうるため、既存の `yakitori_players`（text）を残しつつ、`yakitori_player_ids`（jsonb）を追加する。
+5. 新しい外部キーはすべて `players(id)` を参照し、削除時は `ON DELETE SET NULL` とする。
+6. 新列は初回 migration では `NULLABLE` で導入し、backfill 後も即時 NOT NULL 化しない。
+
+## Migration 列定義（`20260403000000_games_add_player_ids.sql`）
+
+```sql
+-- player 参加者 ID 列
+ALTER TABLE public.games
+  ADD COLUMN IF NOT EXISTS player1_id        BIGINT NULL REFERENCES public.players(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS player2_id        BIGINT NULL REFERENCES public.players(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS player3_id        BIGINT NULL REFERENCES public.players(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS player4_id        BIGINT NULL REFERENCES public.players(id) ON DELETE SET NULL;
+
+-- 派生参照 ID 列
+ALTER TABLE public.games
+  ADD COLUMN IF NOT EXISTS top_player_id     BIGINT NULL REFERENCES public.players(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS last_player_id    BIGINT NULL REFERENCES public.players(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS tobi_player_id    BIGINT NULL REFERENCES public.players(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS tobashi_player_id BIGINT NULL REFERENCES public.players(id) ON DELETE SET NULL;
+
+-- 焼き鳥 ID 配列（jsonb）
+ALTER TABLE public.games
+  ADD COLUMN IF NOT EXISTS yakitori_player_ids JSONB NULL;
+```
+
+インデックス:
+- player1_id〜player4_id: 各 B-tree インデックス
+- top/last/tobi/tobashi_player_id: 各 B-tree インデックス
+- yakitori_player_ids: GIN インデックス
+
+## Data migration 方針（`20260403000001_games_backfill_player_ids.sql`）
+
+- 既存行は `players.name` 完全一致で `player*_id` / 派生 ID 列を backfill する。
+- `yakitori_players`（カンマ区切り）はカンマで分解して `players.name` と照合し、数値 ID の JSON 配列を `yakitori_player_ids` に格納する。
+- 一致しない name・空値・欠損は NULL のまま残す（非破壊）。
+- migration は停止せず、未解決行はコメントに示した検証 SQL で後追い確認できる。
+
+## アプリケーション変更
+
+### 書き込み系（`app/actions.ts`, `app/match-actions.ts`）
+- フォームから受けた player 名一覧を `players` テーブルで一括解決し、`name → id` の Map を作る。
+- `games` insert/update 時に name 列と id 列を同時保存する。
+- yakitori は name CSV と JSON ID 配列を同時に書く。
+
+### 読み取り系（`lib/matches.ts`）
+- `MatchPlayer` に `id: number | null` を追加。
+- `MatchResult` に `topPlayerId`, `lastPlayerId`, `tobiPlayerId`, `tobashiPlayerId`, `yakitoriPlayerIds` を追加。
+- 取得 select に新列を追加し、mapping で ID を取り出す。
+- UI 表示は既存の name 中心を維持する。
+
+### エクスポート（`app/api/export/games/csv-builder.js`）
+- `metadata_json` に `top/last/tobi/tobashi_player_id` と `yakitori_player_ids` を含める。
+- `player_1_id`〜`player_4_id` は `MatchPlayer.id` から出力する（ADR 0002 / 0004 と整合）。
+
+## 削除時の扱い
+
+- `players` 行削除時に `games` 履歴を消すのは不適切なため `CASCADE` は採用しない。
+- `ON DELETE SET NULL` により、対局時点の表示名スナップショットは残り、ID 参照のみ外れる。
+- 現行のプレイヤー削除 UI では参照中プレイヤーを削除できてしまうため、将来的には削除前チェックまたは論理削除の導入を別 issue で検討する。
+
+## 理由
+
+- name と id の併存で「履歴表示互換」と「参照整合性」を両立できる。
+- `yakuman_occurrences` は既に `player_id` を外部キーとして持つため、`games` 側も ID を持つことで一貫性が上がる。
+- nullable 追加と backfill の二段構成により、本番 migration のリスクを最小限に抑えられる。
+- 完全正規化（game_players 中間テーブル化）より変更差分が小さく、既存 UI と CSV を壊しにくい。
+
+## 代替案
+
+- **game_players 中間テーブルへ完全正規化する**
+  - 長期的には有力だが、保存・取得・集計・CSV を全面的に組み直す必要があり、Issue #57 のスコープを超えるため不採用。
+- **player1_id..player4_id だけ追加し、top/last 等は name のまま**
+  - 最小差分だが、派生参照の整合性問題が残るため不採用。
+- **yakitori を name CSV のままにする**
+  - 複数値の参照整合が改善しないため不採用。
+
+## 影響ファイル
+
+| ファイル | 変更内容 |
+|---|---|
+| `supabase/migrations/20260403000000_games_add_player_ids.sql` | 新規: 列・FK・インデックス追加 |
+| `supabase/migrations/20260403000001_games_backfill_player_ids.sql` | 新規: 既存データ backfill |
+| `lib/matches.ts` | 型拡張・select・mapping 更新 |
+| `app/actions.ts` | 保存時の player ID 解決・二重保存 |
+| `app/match-actions.ts` | 編集時の player ID 解決・同期更新 |
+| `app/api/export/games/csv-builder.js` | metadata_json への player ID 出力 |
+| `app/api/export/games/csv-builder.d.ts` | 型定義更新 |
+| `app/api/export/games/handler.d.ts` | 型定義更新 |
+
+## 検証チェックリスト
+
+- [ ] `npx supabase db reset` で migration を適用し、新列・FK・インデックスの存在を確認する。
+- [ ] 既存データで backfill 後、player*_id と name の対応件数・未解決件数を確認 SQL で検証する。
+- [ ] 新規スコア保存で games に name と id が両方入ることを確認する。
+- [ ] 対局編集で name と id が同期して更新されることを確認する。
+- [ ] 対局履歴・統計・役満・CSV 出力に回帰がないことを確認する。
+- [ ] `npm run test` と `npm run build` を実行してパスすることを確認する。
+
+## 残課題（別 issue 対応）
+
+- `player4 IS NULL AND player4_id IS NULL` が 3 人打ちでは正常、4 人打ちで名前未設定（異常）なのかを区別できるようにする。
+- players 削除前のチェックまたは論理削除の導入を別 issue で検討する。
+- `app/player-actions.ts` では insert に `display_name` を渡しているが、現行 `players` migration に `display_name` 列がない。このスキーマ差分を別 issue で解消する。
+- game_players 中間テーブル化による完全正規化は長期的な選択肢として別 issue で再評価する。

--- a/lib/matches.ts
+++ b/lib/matches.ts
@@ -8,6 +8,7 @@ export type YakumanOccurrence = {
 
 export type MatchPlayer = {
   slot: number;
+  id: number | null;
   name: string;
   score: number;
   rank: number;
@@ -24,10 +25,15 @@ export type MatchResult = {
   playerCount: number;
   scoreTotal: number;
   topPlayer: string;
+  topPlayerId: number | null;
   lastPlayer: string;
+  lastPlayerId: number | null;
   tobiPlayer: string | null;
+  tobiPlayerId: number | null;
   tobashiPlayer: string | null;
+  tobashiPlayerId: number | null;
   yakitoriPlayers: string[];
+  yakitoriPlayerIds: number[];
   notes: string;
   createdAt: string;
   players: MatchPlayer[];
@@ -78,7 +84,7 @@ export async function fetchMatchResults(startDate?: string, endDate?: string): P
   const supabase = createClient(supabaseUrl, supabaseKey, { auth: { persistSession: false } });
 
   try {
-    const selection = `id,date,game_type,player_count,player1,player2,player3,player4,score1,score2,score3,score4,rank1,rank2,rank3,rank4,is_tobi1,is_tobi2,is_tobi3,is_tobi4,is_tobashi1,is_tobashi2,is_tobashi3,is_tobashi4,is_yakitori1,is_yakitori2,is_yakitori3,is_yakitori4,score_total,top_player,last_player,tobi_player,tobashi_player,yakitori_players,notes,created_at`;
+    const selection = `id,date,game_type,player_count,player1,player2,player3,player4,player1_id,player2_id,player3_id,player4_id,score1,score2,score3,score4,rank1,rank2,rank3,rank4,is_tobi1,is_tobi2,is_tobi3,is_tobi4,is_tobashi1,is_tobashi2,is_tobashi3,is_tobashi4,is_yakitori1,is_yakitori2,is_yakitori3,is_yakitori4,score_total,top_player,top_player_id,last_player,last_player_id,tobi_player,tobi_player_id,tobashi_player,tobashi_player_id,yakitori_players,yakitori_player_ids,notes,created_at`;
 
     let qb = supabase.from("games").select(selection);
     if (startDate) qb = qb.gte("date", startDate);
@@ -102,8 +108,10 @@ export async function fetchMatchResults(startDate?: string, endDate?: string): P
         .map((slot) => {
           const name = toString(row[`player${slot}`]);
           if (!name) return null;
+          const rawId = row[`player${slot}_id`];
           return {
             slot,
+            id: rawId !== null && rawId !== undefined ? Number(rawId) : null,
             name,
             score: toInt(row[`score${slot}`]),
             rank: toInt(row[`rank${slot}`]) || slots.length,
@@ -119,6 +127,12 @@ export async function fetchMatchResults(startDate?: string, endDate?: string): P
       const createdAtRaw = row["created_at"] ?? row["createdAt"] ?? null;
       const createdAt = createdAtRaw ? new Date(String(createdAtRaw)).toISOString() : "";
 
+      const toNullableId = (v: unknown) => (v !== null && v !== undefined ? Number(v) : null);
+      const rawYakitoriIds = row["yakitori_player_ids"];
+      const yakitoriPlayerIds: number[] = Array.isArray(rawYakitoriIds)
+        ? (rawYakitoriIds as unknown[]).map(Number).filter((n) => Number.isFinite(n))
+        : [];
+
       return {
         id: Number(row["id"] ?? 0),
         date: toString(row["date"]),
@@ -126,13 +140,18 @@ export async function fetchMatchResults(startDate?: string, endDate?: string): P
         playerCount,
         scoreTotal: toInt(row["score_total"]),
         topPlayer: toString(row["top_player"]),
+        topPlayerId: toNullableId(row["top_player_id"]),
         lastPlayer: toString(row["last_player"]),
+        lastPlayerId: toNullableId(row["last_player_id"]),
         tobiPlayer: row["tobi_player"] ? String(row["tobi_player"]) : null,
+        tobiPlayerId: toNullableId(row["tobi_player_id"]),
         tobashiPlayer: row["tobashi_player"] ? String(row["tobashi_player"]) : null,
+        tobashiPlayerId: toNullableId(row["tobashi_player_id"]),
         yakitoriPlayers: String(row["yakitori_players"] ?? "")
           .split(",")
           .map((s) => s.trim())
           .filter(Boolean),
+        yakitoriPlayerIds,
         notes: toString(row["notes"]),
         createdAt,
         players,

--- a/supabase/migrations/20260403000000_games_add_player_ids.sql
+++ b/supabase/migrations/20260403000000_games_add_player_ids.sql
@@ -1,0 +1,37 @@
+-- 20260403000000_games_add_player_ids.sql
+-- Issue #57: games テーブルにプレイヤー参照 ID 列を追加する。
+-- 既存の player 名列はスナップショットとして残す（非破壊マイグレーション）。
+
+-- player 参加者 ID 列
+ALTER TABLE public.games
+  ADD COLUMN IF NOT EXISTS player1_id BIGINT NULL REFERENCES public.players(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS player2_id BIGINT NULL REFERENCES public.players(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS player3_id BIGINT NULL REFERENCES public.players(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS player4_id BIGINT NULL REFERENCES public.players(id) ON DELETE SET NULL;
+
+-- 派生参照 ID 列（トップ・ラス・飛び・飛ばし）
+ALTER TABLE public.games
+  ADD COLUMN IF NOT EXISTS top_player_id    BIGINT NULL REFERENCES public.players(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS last_player_id   BIGINT NULL REFERENCES public.players(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS tobi_player_id   BIGINT NULL REFERENCES public.players(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS tobashi_player_id BIGINT NULL REFERENCES public.players(id) ON DELETE SET NULL;
+
+-- 焼き鳥は複数人を取りうるため jsonb 配列で管理する。
+-- 既存の yakitori_players (text) はスナップショットとして残す。
+ALTER TABLE public.games
+  ADD COLUMN IF NOT EXISTS yakitori_player_ids JSONB NULL;
+
+-- インデックス（参加者 ID）
+CREATE INDEX IF NOT EXISTS idx_games_player1_id ON public.games (player1_id);
+CREATE INDEX IF NOT EXISTS idx_games_player2_id ON public.games (player2_id);
+CREATE INDEX IF NOT EXISTS idx_games_player3_id ON public.games (player3_id);
+CREATE INDEX IF NOT EXISTS idx_games_player4_id ON public.games (player4_id);
+
+-- インデックス（派生参照）
+CREATE INDEX IF NOT EXISTS idx_games_top_player_id      ON public.games (top_player_id);
+CREATE INDEX IF NOT EXISTS idx_games_last_player_id     ON public.games (last_player_id);
+CREATE INDEX IF NOT EXISTS idx_games_tobi_player_id     ON public.games (tobi_player_id);
+CREATE INDEX IF NOT EXISTS idx_games_tobashi_player_id  ON public.games (tobashi_player_id);
+
+-- GIN インデックス（焼き鳥 ID 配列）
+CREATE INDEX IF NOT EXISTS idx_games_yakitori_player_ids ON public.games USING GIN (yakitori_player_ids);

--- a/supabase/migrations/20260403000001_games_backfill_player_ids.sql
+++ b/supabase/migrations/20260403000001_games_backfill_player_ids.sql
@@ -1,0 +1,97 @@
+-- 20260403000001_games_backfill_player_ids.sql
+-- Issue #57: 既存の games 行に player ID を players.name 完全一致で埋める。
+-- 一致しない name・空文字・欠損は NULL のまま残す（非破壊）。
+
+-- player1_id .. player4_id のバックフィル
+UPDATE public.games g
+SET player1_id = p.id
+FROM public.players p
+WHERE g.player1_id IS NULL
+  AND g.player1 IS NOT NULL
+  AND g.player1 <> ''
+  AND p.name = g.player1;
+
+UPDATE public.games g
+SET player2_id = p.id
+FROM public.players p
+WHERE g.player2_id IS NULL
+  AND g.player2 IS NOT NULL
+  AND g.player2 <> ''
+  AND p.name = g.player2;
+
+UPDATE public.games g
+SET player3_id = p.id
+FROM public.players p
+WHERE g.player3_id IS NULL
+  AND g.player3 IS NOT NULL
+  AND g.player3 <> ''
+  AND p.name = g.player3;
+
+UPDATE public.games g
+SET player4_id = p.id
+FROM public.players p
+WHERE g.player4_id IS NULL
+  AND g.player4 IS NOT NULL
+  AND g.player4 <> ''
+  AND p.name = g.player4;
+
+-- top_player_id / last_player_id / tobi_player_id / tobashi_player_id のバックフィル
+UPDATE public.games g
+SET top_player_id = p.id
+FROM public.players p
+WHERE g.top_player_id IS NULL
+  AND g.top_player IS NOT NULL
+  AND g.top_player <> ''
+  AND p.name = g.top_player;
+
+UPDATE public.games g
+SET last_player_id = p.id
+FROM public.players p
+WHERE g.last_player_id IS NULL
+  AND g.last_player IS NOT NULL
+  AND g.last_player <> ''
+  AND p.name = g.last_player;
+
+UPDATE public.games g
+SET tobi_player_id = p.id
+FROM public.players p
+WHERE g.tobi_player_id IS NULL
+  AND g.tobi_player IS NOT NULL
+  AND g.tobi_player <> ''
+  AND p.name = g.tobi_player;
+
+UPDATE public.games g
+SET tobashi_player_id = p.id
+FROM public.players p
+WHERE g.tobashi_player_id IS NULL
+  AND g.tobashi_player IS NOT NULL
+  AND g.tobashi_player <> ''
+  AND p.name = g.tobashi_player;
+
+-- yakitori_player_ids のバックフィル
+-- yakitori_players はカンマ区切り文字列。players と完全一致する名前のみ ID を収集して jsonb 配列にする。
+UPDATE public.games g
+SET yakitori_player_ids = (
+  SELECT jsonb_agg(p.id ORDER BY idx)
+  FROM (
+    SELECT trim(name_val) AS name_val, ordinality - 1 AS idx
+    FROM unnest(string_to_array(g.yakitori_players, ',')) WITH ORDINALITY AS t(name_val, ordinality)
+    WHERE trim(name_val) <> ''
+  ) parts
+  JOIN public.players p ON p.name = parts.name_val
+)
+WHERE g.yakitori_player_ids IS NULL
+  AND g.yakitori_players IS NOT NULL
+  AND g.yakitori_players <> '';
+
+-- 検証用クエリ（migration 後に手動実行して残件を確認する。migration 本体には影響しない）
+-- SELECT
+--   COUNT(*) FILTER (WHERE player1 IS NOT NULL AND player1_id IS NULL) AS player1_unresolved,
+--   COUNT(*) FILTER (WHERE player2 IS NOT NULL AND player2_id IS NULL) AS player2_unresolved,
+--   COUNT(*) FILTER (WHERE player3 IS NOT NULL AND player3_id IS NULL) AS player3_unresolved,
+--   COUNT(*) FILTER (WHERE player4 IS NOT NULL AND player4_id IS NULL) AS player4_unresolved,
+--   COUNT(*) FILTER (WHERE top_player IS NOT NULL AND top_player_id IS NULL)      AS top_unresolved,
+--   COUNT(*) FILTER (WHERE last_player IS NOT NULL AND last_player_id IS NULL)     AS last_unresolved,
+--   COUNT(*) FILTER (WHERE tobi_player IS NOT NULL AND tobi_player_id IS NULL)     AS tobi_unresolved,
+--   COUNT(*) FILTER (WHERE tobashi_player IS NOT NULL AND tobashi_player_id IS NULL) AS tobashi_unresolved
+-- FROM public.games;


### PR DESCRIPTION
## 概要

Issue #57 対応。`games` テーブルへのプレイヤー参照 ID 導入（非破壊移行）。

## 変更内容

### Migration（2本）
- `20260403000000_games_add_player_ids.sql` — `player1_id`〜`player4_id`、`top/last/tobi/tobashi_player_id`、`yakitori_player_ids` を追加（FK `ON DELETE SET NULL`、nullable）
- `20260403000001_games_backfill_player_ids.sql` — `players.name` 完全一致で既存行を backfill

### アプリケーション
- `lib/matches.ts` — `MatchPlayer` に `id`、`MatchResult` に派生 ID フィールドを追加
- `app/actions.ts` — 保存時に player 名 → players.id を解決し name/id を同時保存
- `app/match-actions.ts` — 編集時に同様の id 解決ロジックを追加
- `app/api/export/games/csv-builder.js` — `metadata_json` に player ID 群を出力
- `app/api/export/games/{handler,csv-builder}.d.ts` — 型定義を更新

### ドキュメント
- `design/adr/0006-games-player-ids.md` — ADR を新規追加

## 設計方針

- 既存の player 名列はスナップショットとして **残す**（UI 表示互換）
- 参照整合性は FK（ON DELETE SET NULL）で担保
- backfill は players.name 完全一致で行い、未解決行は NULL でスキップ（非破壊）

## テスト

- `npm run build` ✅
- `npm test` ✅ (2 suites, 2 pass)

## 残課題（別 issue）

- players 削除前チェック / 論理削除の検討
- `app/player-actions.ts` の `display_name` と players スキーマの差分解消
- game_players 中間テーブル化による完全正規化の再評価

## チェックリスト

- [x] `.github/copilot-instructions.md` が存在することを確認
- [x] 機密情報（APIキー等）が含まれていないことを確認
- [x] `npm run build` が成功することを確認
- [x] `npm test` が成功することを確認