### PR TITLE
fix(issue-73): CI workflow bug fixes — YAML parse, secrets in if, psql seed

### DIFF
--- a/.github/workflows/prod-reset-and-seed-players.yml
+++ b/.github/workflows/prod-reset-and-seed-players.yml
@@ -112,23 +112,21 @@ jobs:
           fi
           npx supabase@2.84.2 db push --db-url "$SUPABASE_DB_URL"
 
-      - name: Run seed-players script
-        env:
-          SUPABASE_URL: ${{ secrets.PROD_APP_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.PROD_SUPABASE_SERVICE_ROLE_KEY }}
-          DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
+      - name: Seed players via psql
         run: |
           set -euo pipefail
-          if [ -z "${SUPABASE_URL:-}" ]; then
-            echo "SUPABASE_URL (PROD_APP_URL) is not set; aborting" >&2
-            exit 1
-          fi
-          node scripts/seed-players.mjs
+          psql "$DATABASE_URL" <<'SQL'
+          INSERT INTO public.players (name) VALUES
+            ('杉原'),('沢尾望'),('沢尾徹平'),('山本有美'),('横山'),('前田'),('村上'),
+            ('田宮'),('谷口'),('加藤'),('福本'),('西村'),('山本恭大'),('長谷川彩未'),
+            ('長谷川柊太'),('太雅'),('松原'),('市川'),('徳岡'),('但田')
+          ON CONFLICT (name) DO NOTHING;
+          SQL
+          echo "Seed complete."
 
       - name: Verify players inserted
         run: |
           set -euo pipefail
-          sudo apt-get update && sudo apt-get install -y postgresql-client
           PSQL_URL="$DATABASE_URL"
           echo "Checking players count and presence of specified names..."
           COUNT=$(psql "$PSQL_URL" -tAc "SELECT count(*) FROM players;")

--- a/.github/workflows/staging-reset-and-seed-players.yml
+++ b/.github/workflows/staging-reset-and-seed-players.yml
@@ -112,23 +112,21 @@ jobs:
           fi
           npx supabase@2.84.2 db push --db-url "$SUPABASE_DB_URL"
 
-      - name: Run seed-players script
-        env:
-          SUPABASE_URL: ${{ secrets.STAGING_APP_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.STAGING_SUPABASE_SERVICE_ROLE_KEY }}
-          DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
+      - name: Seed players via psql
         run: |
           set -euo pipefail
-          if [ -z "${SUPABASE_URL:-}" ]; then
-            echo "SUPABASE_URL (STAGING_APP_URL) is not set; aborting" >&2
-            exit 1
-          fi
-          node scripts/seed-players.mjs
+          psql "$DATABASE_URL" <<'SQL'
+          INSERT INTO public.players (name) VALUES
+            ('杉原'),('沢尾望'),('沢尾徹平'),('山本有美'),('横山'),('前田'),('村上'),
+            ('田宮'),('谷口'),('加藤'),('福本'),('西村'),('山本恭大'),('長谷川彩未'),
+            ('長谷川柊太'),('太雅'),('松原'),('市川'),('徳岡'),('但田')
+          ON CONFLICT (name) DO NOTHING;
+          SQL
+          echo "Seed complete."
 
       - name: Verify players inserted
         run: |
           set -euo pipefail
-          sudo apt-get update && sudo apt-get install -y postgresql-client
           PSQL_URL="$DATABASE_URL"
           echo "Checking players count and presence of specified names..."
           COUNT=$(psql "$PSQL_URL" -tAc "SELECT count(*) FROM players;")


### PR DESCRIPTION
## 概要

PR #74（feat(issue-73)）マージ後に発見・修正した CI バグ3件のまとめ PR。

## 変更内容

### commit f92de8b — secrets in if 条件除去
- `if: ${{ secrets.DB_CA_BUNDLE_BASE64 != '' }}` は GitHub Actions の step-level if で無効
- env var に移動し shell-level で空チェックするよう修正

### commit c815fcf — ステップ名のコロンをクォート
- `Optional: write CA bundle ...` の unquoted colon → YAMLパースエラー
- `"Optional: ..."` としてクォート

### commit 0b04677 — seed ステップの SUPABASE_URL バグ修正
- `SUPABASE_URL: ${{ secrets.PROD_APP_URL }}` は Vercel URL（API URL でない）を渡すバグ
- supabase-js 不要の psql ベース `INSERT … ON CONFLICT DO NOTHING` に完全置換
- `postgresql-client` の重複インストールも除去

## テスト

- `npm run build` ✅

## チェックリスト

- [x] `.github/copilot-instructions.md` が存在することを確認
- [x] 機密情報（APIキー等）が含まれていないことを確認
- [x] `npm run build` が成功することを確認