### PR TITLE
fix(ci): fix environment and secret names in reset+seed workflows

### DIFF
--- a/.github/workflows/prod-reset-and-seed-players.yml
+++ b/.github/workflows/prod-reset-and-seed-players.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   reset_and_seed:
     runs-on: ubuntu-latest
-    environment: Production
+    environment: "Production – mj-score-manager-tfvp"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -38,14 +38,14 @@ jobs:
 
       - name: Resolve DATABASE_URL and APP_URL
         env:
-          SECRET_DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
-          SECRET_APP_URL: ${{ secrets.PROD_APP_URL }}
+          SECRET_DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          SECRET_APP_URL: ${{ secrets.APP_URL }}
         run: |
           set -euo pipefail
           DB_URL="${SECRET_DATABASE_URL:-}"
           APP_URL="${SECRET_APP_URL:-}"
           if [ -z "$DB_URL" ]; then
-            echo "PROD_DATABASE_URL secret is empty; aborting" >&2
+            echo "DATABASE_URL secret is empty; aborting" >&2
             exit 1
           fi
           echo "DATABASE_URL will be used from secret"

--- a/.github/workflows/staging-reset-and-seed-players.yml
+++ b/.github/workflows/staging-reset-and-seed-players.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   reset_and_seed:
     runs-on: ubuntu-latest
-    environment: Staging
+    environment: "Preview – mj-score-manager-tfvp"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -38,14 +38,14 @@ jobs:
 
       - name: Resolve DATABASE_URL and APP_URL
         env:
-          SECRET_DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
-          SECRET_APP_URL: ${{ secrets.STAGING_APP_URL }}
+          SECRET_DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          SECRET_APP_URL: ${{ secrets.APP_URL }}
         run: |
           set -euo pipefail
           DB_URL="${SECRET_DATABASE_URL:-}"
           APP_URL="${SECRET_APP_URL:-}"
           if [ -z "$DB_URL" ]; then
-            echo "STAGING_DATABASE_URL secret is empty; aborting" >&2
+            echo "DATABASE_URL secret is empty; aborting" >&2
             exit 1
           fi
           echo "DATABASE_URL will be used from secret"


### PR DESCRIPTION
## 概要

staging/prod ワークフローで environment 名とシークレット名が実際の GitHub 設定と不一致だったバグを修正。

## 変更内容

| | Before | After |
|---|---|---|
| Staging environment | `Staging` | `Preview – mj-score-manager-tfvp` |
| Prod environment | `Production` | `Production – mj-score-manager-tfvp` |
| Staging DB secret | `STAGING_DATABASE_URL` | `DATABASE_URL` |
| Staging App secret | `STAGING_APP_URL` | `APP_URL` |
| Prod DB secret | `PROD_DATABASE_URL` | `DATABASE_URL` |
| Prod App secret | `PROD_APP_URL` | `APP_URL` |

migrate-staging.yml / migrate-prod.yml の実装パターンに合わせた。

## チェックリスト
- [x] `.github/copilot-instructions.md` が存在することを確認
- [x] 機密情報（APIキー等）が含まれていないことを確認
- [x] `npm run build` ✅