### PR TITLE
fix(ci): multi-fallback secret resolution for reset+seed workflows

### DIFF
--- a/.github/workflows/prod-reset-and-seed-players.yml
+++ b/.github/workflows/prod-reset-and-seed-players.yml
@@ -40,15 +40,22 @@ jobs:
         env:
           SECRET_DATABASE_URL: ${{ secrets.DATABASE_URL }}
           SECRET_APP_URL: ${{ secrets.APP_URL }}
+          PROD_DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
+          PROD_APP_URL: ${{ secrets.PROD_APP_URL }}
         run: |
           set -euo pipefail
           DB_URL="${SECRET_DATABASE_URL:-}"
           APP_URL="${SECRET_APP_URL:-}"
           if [ -z "$DB_URL" ]; then
-            echo "DATABASE_URL secret is empty; aborting" >&2
+            DB_URL="${PROD_DATABASE_URL:-}"
+          fi
+          if [ -z "$APP_URL" ]; then
+            APP_URL="${PROD_APP_URL:-}"
+          fi
+          if [ -z "$DB_URL" ]; then
+            echo "None of DATABASE_URL / PROD_DATABASE_URL are set; aborting" >&2
             exit 1
           fi
-          echo "DATABASE_URL will be used from secret"
           echo "DATABASE_URL=$DB_URL" >> "$GITHUB_ENV"
           echo "APP_URL=$APP_URL" >> "$GITHUB_ENV"
 

--- a/.github/workflows/staging-reset-and-seed-players.yml
+++ b/.github/workflows/staging-reset-and-seed-players.yml
@@ -40,15 +40,24 @@ jobs:
         env:
           SECRET_DATABASE_URL: ${{ secrets.DATABASE_URL }}
           SECRET_APP_URL: ${{ secrets.APP_URL }}
+          PREVIEW_DATABASE_URL: ${{ secrets.PREVIEW_DATABASE_URL }}
+          STAGING_DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
+          PREVIEW_APP_URL: ${{ secrets.PREVIEW_APP_URL }}
+          STAGING_APP_URL: ${{ secrets.STAGING_APP_URL }}
         run: |
           set -euo pipefail
           DB_URL="${SECRET_DATABASE_URL:-}"
           APP_URL="${SECRET_APP_URL:-}"
           if [ -z "$DB_URL" ]; then
-            echo "DATABASE_URL secret is empty; aborting" >&2
+            DB_URL="${STAGING_DATABASE_URL:-${PREVIEW_DATABASE_URL:-}}"
+          fi
+          if [ -z "$APP_URL" ]; then
+            APP_URL="${STAGING_APP_URL:-${PREVIEW_APP_URL:-}}"
+          fi
+          if [ -z "$DB_URL" ]; then
+            echo "None of DATABASE_URL / STAGING_DATABASE_URL / PREVIEW_DATABASE_URL are set; aborting" >&2
             exit 1
           fi
-          echo "DATABASE_URL will be used from secret"
           echo "DATABASE_URL=$DB_URL" >> "$GITHUB_ENV"
           echo "APP_URL=$APP_URL" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
## 概要

STAGING_DATABASE_URL が 'Preview – mj-score-manager-tfvp' 環境スコープのシークレットであることを確認し、migrate-common.yml と同じフォールバックロジックを採用。

## 変更詳細

- staging: `DATABASE_URL` → `STAGING_DATABASE_URL` → `PREVIEW_DATABASE_URL` の順でフォールバック
- prod: `DATABASE_URL` → `PROD_DATABASE_URL` の順でフォールバック

## チェックリスト
- [x] `.github/copilot-instructions.md` が存在することを確認
- [x] `npm run build` ✅