### PR TITLE
fix(issue-67): 入力チェック — 重複プレイヤーと飛び/飛ばしの防止 + バリデータ単体テスト (#84)

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -2,88 +2,7 @@
 
 import { createClient } from "@supabase/supabase-js";
 import { revalidatePath } from "next/cache";
-const NONE_VALUE = "__none__";
-const SCORE_TOLERANCE = 1;
-
-type GameType = "3p" | "4p";
-
-type GameEntry = {
-  slot: number;
-  player: string;
-  score: number;
-  rank: number;
-  isTobi: boolean;
-  isTobashi: boolean;
-  isYakitori: boolean;
-};
-
-function parseGameType(value: FormDataEntryValue | null): GameType {
-  return value === "4p" ? "4p" : "3p";
-}
-
-function parseString(value: FormDataEntryValue | null) {
-  return String(value ?? "").trim();
-}
-
-function parseOptionalPlayer(value: FormDataEntryValue | null) {
-  const parsed = parseString(value);
-  return !parsed || parsed === NONE_VALUE ? null : parsed;
-}
-
-function parseScore(value: FormDataEntryValue | null) {
-  const raw = parseString(value);
-  if (!raw) {
-    return null;
-  }
-
-  const parsed = Number(raw);
-  if (!Number.isInteger(parsed) || parsed < -1000 || parsed > 1000) {
-    return null;
-  }
-
-  return parsed;
-}
-
-function validatePlayer(name: string, label: string) {
-  if (!name) {
-    return `${label}を選択してください`;
-  }
-
-  return null;
-}
-
-function buildRankedEntries(
-  players: string[],
-  scores: number[],
-  yakitoriPlayers: Set<string>,
-  tobiPlayer: string | null,
-  tobashiPlayer: string | null
-) {
-  const ranked = players
-    .map((player, index) => ({
-      slot: index + 1,
-      player,
-      score: scores[index],
-    }))
-    .sort((left, right) => right.score - left.score || left.slot - right.slot)
-    .map((entry, index) => ({
-      ...entry,
-      rank: index + 1,
-    }));
-
-  const rankBySlot = new Map(ranked.map((entry) => [entry.slot, entry.rank]));
-
-  return players.map((player, index) => ({
-    slot: index + 1,
-    player,
-    score: scores[index],
-    rank: rankBySlot.get(index + 1) ?? players.length,
-    isTobi: tobiPlayer === player,
-    isTobashi: tobashiPlayer === player,
-    isYakitori: yakitoriPlayers.has(player),
-  })) satisfies GameEntry[];
-}
-
+import { validateAndParseMatchForm, buildRankedEntries } from "@/lib/validate-match";
 export type SaveScoreState = {
   success: boolean;
   message: string;
@@ -93,98 +12,27 @@ export async function saveScoreAction(
   _prevState: SaveScoreState,
   formData: FormData
 ): Promise<SaveScoreState> {
-  const gameDate = parseString(formData.get("gameDate"));
-  if (!gameDate) {
-    return { success: false, message: "対局日を入力してください" };
+  const validated = validateAndParseMatchForm(formData);
+  if (!validated.ok) {
+    return { success: false, message: validated.message };
   }
 
-  const gameType = parseGameType(formData.get("gameType"));
-  const activeSlots = gameType === "4p" ? [1, 2, 3, 4] : [1, 2, 3];
-
-  const players = activeSlots.map((slot) => parseString(formData.get(`player${slot}`)));
-  for (const [index, player] of players.entries()) {
-    const error = validatePlayer(player, `プレイヤー${index + 1}`);
-    if (error) {
-      return { success: false, message: error };
-    }
-  }
-
-  if (new Set(players).size !== players.length) {
-    return {
-      success: false,
-      message: `${gameType === "4p" ? "4名" : "3名"}とも別の名前を選択してください。`,
-    };
-  }
-
-  const scores = activeSlots.map((slot, index) => {
-    const score = parseScore(formData.get(`score${slot}`));
-    return {
-      index,
-      score,
-    };
-  });
-
-  const invalidScore = scores.find(({ score }) => score === null);
-  if (invalidScore) {
-    return {
-      success: false,
-      message: `スコア${invalidScore.index + 1}は -1000 から 1000 の整数で入力してください。`,
-    };
-  }
-
-  const resolvedScores = scores.map(({ score }) => score as number);
-  const total = resolvedScores.reduce((sum, score) => sum + score, 0);
-
-  if (Math.abs(total) > SCORE_TOLERANCE) {
-    return {
-      success: false,
-      message: "最終スコア合計は 0 にしてください。四捨五入の記載誤差として ±1 までは許容しています。",
-    };
-  }
-
-  const tobiPlayer = parseOptionalPlayer(formData.get("tobiPlayer"));
-  const tobashiPlayer = parseOptionalPlayer(formData.get("tobashiPlayer"));
-  const yakitoriPlayers = new Set(
-    activeSlots
-      .filter((slot) => formData.get(`yakitori${slot}`) === "on")
-      .map((slot, index) => players[index])
-      .filter(Boolean)
-  );
-
-  if ((tobiPlayer && !tobashiPlayer) || (!tobiPlayer && tobashiPlayer)) {
-    return {
-      success: false,
-      message: "飛びと飛ばしは両方セットで指定してください。",
-    };
-  }
-
-  if (tobiPlayer && !players.includes(tobiPlayer)) {
-    return {
-      success: false,
-      message: "飛び対象は同卓プレイヤーから選択してください。",
-    };
-  }
-
-  if (tobashiPlayer && !players.includes(tobashiPlayer)) {
-    return {
-      success: false,
-      message: "飛ばし者は同卓プレイヤーから選択してください。",
-    };
-  }
-
-  if (tobiPlayer && tobashiPlayer && tobiPlayer === tobashiPlayer) {
-    return {
-      success: false,
-      message: "飛び対象と飛ばし者に同じプレイヤーは指定できません。",
-    };
-  }
+  const {
+    gameDate,
+    gameType,
+    players,
+    scores: resolvedScores,
+    tobiPlayer,
+    tobashiPlayer,
+    yakitoriPlayers,
+    notes,
+    total,
+  } = validated.data;
 
   const entries = buildRankedEntries(players, resolvedScores, yakitoriPlayers, tobiPlayer, tobashiPlayer);
   const rankedEntries = [...entries].sort((left, right) => left.rank - right.rank);
   const topPlayer = rankedEntries[0]?.player ?? "";
   const lastPlayer = rankedEntries[rankedEntries.length - 1]?.player ?? "";
-
-  const notes = parseString(formData.get("notes"));
 
   
   const supabaseUrl = process.env.SUPABASE_URL;
@@ -271,7 +119,7 @@ export async function saveScoreAction(
 
     // handle yakuman occurrences submitted as a JSON list
     const yakRows: Array<Record<string, unknown>> = [];
-    const yakumanSelectionsRaw = parseString(formData.get("yakumanSelections"));
+    const yakumanSelectionsRaw = String(formData.get("yakumanSelections") ?? "").trim();
     let yakumanSelections: Array<{ playerName: string; yakumanCode: string; yakumanName: string }> = [];
 
     if (yakumanSelectionsRaw) {

--- a/app/match-actions.ts
+++ b/app/match-actions.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { createClient } from "@supabase/supabase-js";
-
+import { validateAndParseMatchForm, buildRankedEntries } from "@/lib/validate-match";
 export type DeleteMatchState = {
   success: boolean;
   message: string;
@@ -44,39 +44,6 @@ export type EditMatchState = {
   success: boolean;
   message: string;
 };
-
-const NONE_VALUE = "__none__";
-const SCORE_TOLERANCE = 1;
-
-type GameType = "3p" | "4p";
-
-function parseGameType(value: FormDataEntryValue | null): GameType {
-  return value === "4p" ? "4p" : "3p";
-}
-
-function parseString(value: FormDataEntryValue | null) {
-  return String(value ?? "").trim();
-}
-
-function parseOptionalPlayer(value: FormDataEntryValue | null) {
-  const parsed = parseString(value);
-  return !parsed || parsed === NONE_VALUE ? null : parsed;
-}
-
-function parseScore(value: FormDataEntryValue | null) {
-  const raw = parseString(value);
-  if (!raw) {
-    return null;
-  }
-
-  const parsed = Number(raw);
-  if (!Number.isInteger(parsed) || parsed < -1000 || parsed > 1000) {
-    return null;
-  }
-
-  return parsed;
-}
-
 type YakumanSelection = {
   playerName: string;
   yakumanCode: string;
@@ -114,46 +81,6 @@ function parseYakumanSelections(value: FormDataEntryValue | null): YakumanSelect
   }
 }
 
-function validatePlayer(name: string, label: string) {
-  if (!name) {
-    return `${label}を選択してください`;
-  }
-
-  return null;
-}
-
-function buildRankedEntries(
-  players: string[],
-  scores: number[],
-  yakitoriPlayers: Set<string>,
-  tobiPlayer: string | null,
-  tobashiPlayer: string | null
-) {
-  const ranked = players
-    .map((player, index) => ({
-      slot: index + 1,
-      player,
-      score: scores[index],
-    }))
-    .sort((left, right) => right.score - left.score || left.slot - right.slot)
-    .map((entry, index) => ({
-      ...entry,
-      rank: index + 1,
-    }));
-
-  const rankBySlot = new Map(ranked.map((entry) => [entry.slot, entry.rank]));
-
-  return players.map((player, index) => ({
-    slot: index + 1,
-    player,
-    score: scores[index],
-    rank: rankBySlot.get(index + 1) ?? players.length,
-    isTobi: tobiPlayer === player,
-    isTobashi: tobashiPlayer === player,
-    isYakitori: yakitoriPlayers.has(player),
-  }));
-}
-
 export async function editMatchAction(
   _prevState: EditMatchState | undefined,
   formData: FormData
@@ -164,98 +91,28 @@ export async function editMatchAction(
     return { success: false, message: "対局IDが不正です。" };
   }
 
-  const gameDate = parseString(formData.get("gameDate"));
-  if (!gameDate) {
-    return { success: false, message: "対局日を入力してください" };
+  const validated = validateAndParseMatchForm(formData);
+  if (!validated.ok) {
+    return { success: false, message: validated.message };
   }
 
-  const gameType = parseGameType(formData.get("gameType"));
-  const activeSlots = gameType === "4p" ? [1, 2, 3, 4] : [1, 2, 3];
-
-  const players = activeSlots.map((slot) => parseString(formData.get(`player${slot}`)));
-  for (const [index, player] of players.entries()) {
-    const error = validatePlayer(player, `プレイヤー${index + 1}`);
-    if (error) {
-      return { success: false, message: error };
-    }
-  }
-
-  if (new Set(players).size !== players.length) {
-    return {
-      success: false,
-      message: `${gameType === "4p" ? "4名" : "3名"}とも別の名前を選択してください。`,
-    };
-  }
-
-  const scores = activeSlots.map((slot, index) => {
-    const score = parseScore(formData.get(`score${slot}`));
-    return {
-      index,
-      score,
-    };
-  });
-
-  const invalidScore = scores.find(({ score }) => score === null);
-  if (invalidScore) {
-    return {
-      success: false,
-      message: `スコア${invalidScore.index + 1}は -1000 から 1000 の整数で入力してください。`,
-    };
-  }
-
-  const resolvedScores = scores.map(({ score }) => score as number);
-  const total = resolvedScores.reduce((sum, score) => sum + score, 0);
-
-  if (Math.abs(total) > SCORE_TOLERANCE) {
-    return {
-      success: false,
-      message: "最終スコア合計は 0 にしてください。四捨五入の記載誤差として ±1 までは許容しています。",
-    };
-  }
-
-  const tobiPlayer = parseOptionalPlayer(formData.get("tobiPlayer"));
-  const tobashiPlayer = parseOptionalPlayer(formData.get("tobashiPlayer"));
-  const yakitoriPlayers = new Set(
-    activeSlots
-      .filter((slot) => formData.get(`yakitori${slot}`) === "on")
-      .map((slot, index) => players[index])
-      .filter(Boolean)
-  );
-
-  if ((tobiPlayer && !tobashiPlayer) || (!tobiPlayer && tobashiPlayer)) {
-    return {
-      success: false,
-      message: "飛びと飛ばしは両方セットで指定してください。",
-    };
-  }
-
-  if (tobiPlayer && !players.includes(tobiPlayer)) {
-    return {
-      success: false,
-      message: "飛び対象は同卓プレイヤーから選択してください。",
-    };
-  }
-
-  if (tobashiPlayer && !players.includes(tobashiPlayer)) {
-    return {
-      success: false,
-      message: "飛ばし者は同卓プレイヤーから選択してください。",
-    };
-  }
-
-  if (tobiPlayer && tobashiPlayer && tobiPlayer === tobashiPlayer) {
-    return {
-      success: false,
-      message: "飛び対象と飛ばし者に同じプレイヤーは指定できません。",
-    };
-  }
+  const {
+    gameDate,
+    gameType,
+    players,
+    scores: resolvedScores,
+    tobiPlayer,
+    tobashiPlayer,
+    yakitoriPlayers,
+    notes,
+    total,
+  } = validated.data;
 
   const entries = buildRankedEntries(players, resolvedScores, yakitoriPlayers, tobiPlayer, tobashiPlayer);
   const rankedEntries = [...entries].sort((left, right) => left.rank - right.rank);
   const topPlayer = rankedEntries[0]?.player ?? "";
   const lastPlayer = rankedEntries[rankedEntries.length - 1]?.player ?? "";
 
-  const notes = parseString(formData.get("notes"));
   const yakumanSelections = parseYakumanSelections(formData.get("yakumanSelections"));
 
   const supabaseUrl = process.env.SUPABASE_URL;

--- a/components/match-edit-form.tsx
+++ b/components/match-edit-form.tsx
@@ -52,6 +52,7 @@ export function MatchEditForm({ match, players: playerList, createdAt, yakumans 
   const [state, formAction] = useActionState(editMatchAction, initialState);
   const [pending, startTransition] = useTransition();
   const [clientError, setClientError] = useState<string | null>(null);
+  const [duplicatePlayerError, setDuplicatePlayerError] = useState<string | null>(null);
   const [gameType, setGameType] = useState<GameType>(match.gameType);
   const [gameDate, setGameDate] = useState(match.date);
   const [players, setPlayers] = useState<PlayerSelection>({
@@ -170,6 +171,20 @@ export function MatchEditForm({ match, players: playerList, createdAt, yakumans 
   }, [gameType, players, scores]);
 
   useEffect(() => {
+    const selectedPlayers = activeSlots
+      .map((slot) => players[slot as keyof PlayerSelection])
+      .filter(Boolean);
+    const uniquePlayers = new Set(selectedPlayers);
+
+    if (uniquePlayers.size !== selectedPlayers.length) {
+      setDuplicatePlayerError("同じプレイヤーを重複して選択できません。");
+      return;
+    }
+
+    setDuplicatePlayerError(null);
+  }, [activeSlots, players]);
+
+  useEffect(() => {
     if (gameType === "3p") {
       setPlayers((current) => ({ ...current, 4: "" }));
       setScores((current) => ({ ...current, 4: "" }));
@@ -215,6 +230,11 @@ export function MatchEditForm({ match, players: playerList, createdAt, yakumans 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setClientError(null);
+    if (duplicatePlayerError) {
+      setClientError(duplicatePlayerError);
+      return;
+    }
+
     const form = createFormData();
     startTransition(() => {
       formAction(form);
@@ -270,6 +290,10 @@ export function MatchEditForm({ match, players: playerList, createdAt, yakumans 
                     if (value === tobashiPlayer) setTobashiPlayer(NONE_VALUE);
                   }}
                   options={playerList}
+                  exclude={activeSlots
+                    .filter((s) => s !== slot)
+                    .map((s) => players[s as keyof PlayerSelection])
+                    .filter(Boolean)}
                   required
                 />
               </div>
@@ -445,11 +469,14 @@ export function MatchEditForm({ match, players: playerList, createdAt, yakumans 
             </SelectTrigger>
             <SelectContent>
               <SelectItem value={NONE_VALUE}>なし</SelectItem>
-              {playersToCheck.map((player) => (
-                <SelectItem key={`tobi-${player}`} value={player}>
-                  {player} が飛び
-                </SelectItem>
-              ))}
+              {playersToCheck.map((player) => {
+                const isDisabled = player === tobashiPlayer && player !== tobiPlayer;
+                return (
+                  <SelectItem key={`tobi-${player}`} value={player} disabled={isDisabled}>
+                    {player} が飛び
+                  </SelectItem>
+                );
+              })}
             </SelectContent>
           </Select>
           <Select value={tobashiPlayer} onValueChange={setTobashiPlayer}>
@@ -458,11 +485,14 @@ export function MatchEditForm({ match, players: playerList, createdAt, yakumans 
             </SelectTrigger>
             <SelectContent>
               <SelectItem value={NONE_VALUE}>なし</SelectItem>
-              {playersToCheck.map((player) => (
-                <SelectItem key={`tobashi-${player}`} value={player}>
-                  {player} が飛ばし
-                </SelectItem>
-              ))}
+              {playersToCheck.map((player) => {
+                const isDisabled = player === tobiPlayer && player !== tobashiPlayer;
+                return (
+                  <SelectItem key={`tobashi-${player}`} value={player} disabled={isDisabled}>
+                    {player} が飛ばし
+                  </SelectItem>
+                );
+              })}
             </SelectContent>
           </Select>
         </div>
@@ -488,6 +518,12 @@ export function MatchEditForm({ match, players: playerList, createdAt, yakumans 
         </Alert>
       )}
 
+      {duplicatePlayerError && !clientError ? (
+        <Alert className="border-destructive/40 bg-destructive/5 text-destructive">
+          <AlertDescription>{duplicatePlayerError}</AlertDescription>
+        </Alert>
+      ) : null}
+
       {state.message && (
         <Alert
           className={state.success ? "border-emerald-300 bg-emerald-50 text-emerald-800" : "border-destructive/40 bg-destructive/5 text-destructive"}
@@ -497,7 +533,7 @@ export function MatchEditForm({ match, players: playerList, createdAt, yakumans 
       )}
 
       <div className="flex flex-col gap-2 pt-4 sm:flex-row">
-        <Button type="submit" disabled={pending || clientError !== null} className="w-full flex-1">
+        <Button type="submit" disabled={pending || clientError !== null || duplicatePlayerError !== null} className="w-full flex-1">
           {pending ? "編集中..." : "対局を編集"}
         </Button>
         <Button type="button" variant="outline" onClick={() => window.history.back()} className="w-full sm:w-auto">

--- a/components/score-form.tsx
+++ b/components/score-form.tsx
@@ -339,6 +339,10 @@ export function ScoreForm({ players: playerList }: ScoreFormProps) {
                       }))
                     }
                     options={playerOptions}
+                    exclude={activeSlots
+                      .filter((s) => s !== slot)
+                      .map((s) => players[s as keyof PlayerSelection])
+                      .filter(Boolean)}
                     onAddPlayer={handleAddPlayer}
                     required
                   />
@@ -402,34 +406,40 @@ export function ScoreForm({ players: playerList }: ScoreFormProps) {
 
             <div className="space-y-2">
               <Label>飛び対象</Label>
-              <Select name="tobiPlayer" value={tobiPlayer} onValueChange={setTobiPlayer}>
+                <Select name="tobiPlayer" value={tobiPlayer} onValueChange={setTobiPlayer}>
                 <SelectTrigger>
                   <SelectValue placeholder="なし" />
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value={NONE_VALUE}>なし</SelectItem>
-                  {activePlayers.map((player) => (
-                    <SelectItem key={`tobi-${player.name}`} value={player.name}>
-                      {player.name}
-                    </SelectItem>
-                  ))}
+                    {activePlayers.map((player) => {
+                      const isDisabled = player.name === tobashiPlayer && player.name !== tobiPlayer;
+                      return (
+                        <SelectItem key={`tobi-${player.name}`} value={player.name} disabled={isDisabled}>
+                          {player.name}
+                        </SelectItem>
+                      );
+                    })}
                 </SelectContent>
               </Select>
             </div>
 
             <div className="space-y-2">
               <Label>飛ばし者</Label>
-              <Select name="tobashiPlayer" value={tobashiPlayer} onValueChange={setTobashiPlayer}>
+                <Select name="tobashiPlayer" value={tobashiPlayer} onValueChange={setTobashiPlayer}>
                 <SelectTrigger>
                   <SelectValue placeholder="なし" />
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value={NONE_VALUE}>なし</SelectItem>
-                  {activePlayers.map((player) => (
-                    <SelectItem key={`tobashi-${player.name}`} value={player.name}>
-                      {player.name}
-                    </SelectItem>
-                  ))}
+                    {activePlayers.map((player) => {
+                      const isDisabled = player.name === tobiPlayer && player.name !== tobashiPlayer;
+                      return (
+                        <SelectItem key={`tobashi-${player.name}`} value={player.name} disabled={isDisabled}>
+                          {player.name}
+                        </SelectItem>
+                      );
+                    })}
                 </SelectContent>
               </Select>
             </div>

--- a/components/ui/player-select.tsx
+++ b/components/ui/player-select.tsx
@@ -9,6 +9,7 @@ type Props = {
   value: string;
   onValueChange: (value: string) => void;
   options: string[];
+  exclude?: string[];
   placeholder?: string;
   required?: boolean;
   onAddPlayer?: (name: string) => Promise<{ success: boolean; message: string }>;
@@ -19,6 +20,7 @@ export function PlayerSelect({
   value,
   onValueChange,
   options,
+  exclude,
   placeholder = "選択してください",
   required,
   onAddPlayer,
@@ -143,20 +145,32 @@ export function PlayerSelect({
                 「{trimmedQuery}」は見つかりません
               </li>
             ) : (
-              filtered.map((option) => (
-                <li
-                  key={option}
-                  role="option"
-                  aria-selected={option === value}
-                  onClick={() => handleSelect(option)}
-                  className={cn(
-                    "cursor-pointer px-3 py-2 text-sm hover:bg-emerald-50",
-                    option === value && "bg-emerald-100 font-semibold text-emerald-900"
-                  )}
-                >
-                  {option}
-                </li>
-              ))
+              filtered.map((option) => {
+                const excludedList = Array.isArray(exclude) ? exclude : [];
+                const isDisabled = Boolean(excludedList.includes(option) && option !== value);
+
+                return (
+                  <li
+                    key={option}
+                    role="option"
+                    aria-selected={option === value}
+                    aria-disabled={isDisabled}
+                    onClick={() => {
+                      if (isDisabled) return;
+                      handleSelect(option);
+                    }}
+                    className={cn(
+                      "px-3 py-2 text-sm",
+                      isDisabled
+                        ? "text-muted-foreground cursor-not-allowed opacity-60"
+                        : "cursor-pointer hover:bg-emerald-50",
+                      option === value && "bg-emerald-100 font-semibold text-emerald-900"
+                    )}
+                  >
+                    {option}
+                  </li>
+                );
+              })
             )}
           </ul>
 

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -51,23 +51,26 @@ SelectContent.displayName = SelectPrimitive.Content.displayName;
 const SelectItem = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
->(({ className, children, ...props }, ref) => (
-  <SelectPrimitive.Item
-    ref={ref}
-    className={cn(
-      "relative flex w-full cursor-default select-none items-center rounded-sm py-2 pl-8 pr-2 text-sm outline-none focus:bg-muted",
-      className
-    )}
-    {...props}
-  >
-    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-      <SelectPrimitive.ItemIndicator>
-        <Check className="h-4 w-4" />
-      </SelectPrimitive.ItemIndicator>
-    </span>
-    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
-  </SelectPrimitive.Item>
-));
+>(({ className, children, disabled, ...props }, ref) => {
+  return (
+    <SelectPrimitive.Item
+      ref={ref}
+      className={cn(
+        "relative flex w-full select-none items-center rounded-sm py-2 pl-8 pr-2 text-sm outline-none focus:bg-muted",
+        disabled ? "text-muted-foreground cursor-not-allowed opacity-60" : "cursor-default",
+        className
+      )}
+      {...props}
+    >
+      <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <Check className="h-4 w-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  );
+});
 SelectItem.displayName = SelectPrimitive.Item.displayName;
 
 export { Select, SelectContent, SelectItem, SelectTrigger, SelectValue };

--- a/lib/validate-match.ts
+++ b/lib/validate-match.ts
@@ -1,0 +1,175 @@
+const NONE_VALUE = "__none__";
+const SCORE_TOLERANCE = 1;
+
+export type GameType = "3p" | "4p";
+
+export type GameEntry = {
+  slot: number;
+  player: string;
+  score: number;
+  rank: number;
+  isTobi: boolean;
+  isTobashi: boolean;
+  isYakitori: boolean;
+};
+
+function parseGameType(value: FormDataEntryValue | null): GameType {
+  return value === "4p" ? "4p" : "3p";
+}
+
+function parseString(value: FormDataEntryValue | null) {
+  return String(value ?? "").trim();
+}
+
+function parseOptionalPlayer(value: FormDataEntryValue | null) {
+  const parsed = parseString(value);
+  return !parsed || parsed === NONE_VALUE ? null : parsed;
+}
+
+function parseScore(value: FormDataEntryValue | null) {
+  const raw = parseString(value);
+  if (!raw) {
+    return null;
+  }
+
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < -1000 || parsed > 1000) {
+    return null;
+  }
+
+  return parsed;
+}
+
+export type ParsedMatchData = {
+  gameDate: string;
+  gameType: GameType;
+  activeSlots: number[];
+  players: string[];
+  scores: number[];
+  tobiPlayer: string | null;
+  tobashiPlayer: string | null;
+  yakitoriPlayers: Set<string>;
+  notes: string;
+  total: number;
+};
+
+export function validateAndParseMatchForm(formData: FormData): { ok: true; data: ParsedMatchData } | { ok: false; message: string } {
+  const gameDate = parseString(formData.get("gameDate"));
+  if (!gameDate) {
+    return { ok: false, message: "対局日を入力してください" };
+  }
+
+  const gameType = parseGameType(formData.get("gameType"));
+  const activeSlots = gameType === "4p" ? [1, 2, 3, 4] : [1, 2, 3];
+
+  const players = activeSlots.map((slot) => parseString(formData.get(`player${slot}`)));
+  for (const [index, player] of players.entries()) {
+    if (!player) {
+      return { ok: false, message: `プレイヤー${index + 1}を選択してください` };
+    }
+  }
+
+  if (new Set(players).size !== players.length) {
+    return {
+      ok: false,
+      message: `${gameType === "4p" ? "4名" : "3名"}とも別の名前を選択してください。`,
+    };
+  }
+
+  const scores = activeSlots.map((slot, index) => {
+    const score = parseScore(formData.get(`score${slot}`));
+    return { index, score };
+  });
+
+  const invalidScore = scores.find(({ score }) => score === null);
+  if (invalidScore) {
+    return { ok: false, message: `スコア${invalidScore.index + 1}は -1000 から 1000 の整数で入力してください。` };
+  }
+
+  const resolvedScores = scores.map(({ score }) => score as number);
+  const total = resolvedScores.reduce((sum, score) => sum + score, 0);
+
+  if (Math.abs(total) > SCORE_TOLERANCE) {
+    return {
+      ok: false,
+      message: "最終スコア合計は 0 にしてください。四捨五入の記載誤差として ±1 までは許容しています。",
+    };
+  }
+
+  const tobiPlayer = parseOptionalPlayer(formData.get("tobiPlayer"));
+  const tobashiPlayer = parseOptionalPlayer(formData.get("tobashiPlayer"));
+  const yakitoriPlayers = new Set(
+    activeSlots
+      .filter((slot) => formData.get(`yakitori${slot}`) === "on")
+      .map((slot, index) => players[index])
+      .filter(Boolean)
+  );
+
+  if ((tobiPlayer && !tobashiPlayer) || (!tobiPlayer && tobashiPlayer)) {
+    return { ok: false, message: "飛びと飛ばしは両方セットで指定してください。" };
+  }
+
+  if (tobiPlayer && !players.includes(tobiPlayer)) {
+    return { ok: false, message: "飛び対象は同卓プレイヤーから選択してください。" };
+  }
+
+  if (tobashiPlayer && !players.includes(tobashiPlayer)) {
+    return { ok: false, message: "飛ばし者は同卓プレイヤーから選択してください。" };
+  }
+
+  if (tobiPlayer && tobashiPlayer && tobiPlayer === tobashiPlayer) {
+    return { ok: false, message: "飛び対象と飛ばし者に同じプレイヤーは指定できません。" };
+  }
+
+  const notes = parseString(formData.get("notes"));
+
+  return {
+    ok: true,
+    data: {
+      gameDate,
+      gameType,
+      activeSlots,
+      players,
+      scores: resolvedScores,
+      tobiPlayer,
+      tobashiPlayer,
+      yakitoriPlayers,
+      notes,
+      total,
+    },
+  };
+}
+
+export function buildRankedEntries(
+  players: string[],
+  scores: number[],
+  yakitoriPlayers: Set<string>,
+  tobiPlayer: string | null,
+  tobashiPlayer: string | null
+) {
+  const ranked = players
+    .map((player, index) => ({
+      slot: index + 1,
+      player,
+      score: scores[index],
+    }))
+    .sort((left, right) => right.score - left.score || left.slot - right.slot)
+    .map((entry, index) => ({
+      ...entry,
+      rank: index + 1,
+    }));
+
+  const rankBySlot = new Map(ranked.map((entry) => [entry.slot, entry.rank]));
+
+  return players.map((player, index) => ({
+    slot: index + 1,
+    player,
+    score: scores[index],
+    rank: rankBySlot.get(index + 1) ?? players.length,
+    isTobi: tobiPlayer === player,
+    isTobashi: tobashiPlayer === player,
+    isYakitori: yakitoriPlayers.has(player),
+  })) as GameEntry[];
+}
+
+// no default export

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "husky": "^8.0.0",
         "postcss": "^8.4.49",
         "tailwindcss": "^3.4.16",
+        "ts-node": "^10.9.2",
         "typescript": "^5.7.2"
       },
       "engines": {
@@ -51,6 +52,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@emnapi/core": {
@@ -2063,6 +2088,34 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -2705,6 +2758,19 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {
@@ -3419,6 +3485,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3606,6 +3679,16 @@
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/dlv": {
       "version": "1.1.3",
@@ -5638,6 +5721,13 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -7399,6 +7489,57 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -7687,6 +7828,13 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -7837,6 +7985,16 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "next lint",
     "seeds": "node scripts/seed-to-supabase.mjs",
     "seed:players": "node scripts/seed-players.mjs",
-    "test": "node --test",
+    "test": "node --test && node -r ts-node/register test/validate-match.cjs",
     "check:required-files": "bash -c \"if [ ! -f .github/copilot-instructions.md ]; then echo '\".github/copilot-instructions.md\" が存在しません。コミットを中止します。'; exit 1; fi\"",
     "supabase:init": "npx supabase@2.84.2 init",
     "supabase:start": "npx supabase@2.84.2 start",
@@ -48,6 +48,7 @@
     "husky": "^8.0.0",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.16",
+    "ts-node": "^10.9.2",
     "typescript": "^5.7.2"
   },
   "engines": {

--- a/test/validate-match.cjs
+++ b/test/validate-match.cjs
@@ -1,0 +1,129 @@
+const assert = require('node:assert/strict');
+
+// Ensure ts-node can require TypeScript modules
+require('ts-node').register({ transpileOnly: true, preferTsExts: true });
+
+const { validateAndParseMatchForm } = require('../lib/validate-match.ts');
+
+function fdFrom(obj) {
+  const fd = new FormData();
+  for (const [k, v] of Object.entries(obj)) {
+    if (Array.isArray(v)) {
+      for (const item of v) fd.append(k, String(item));
+    } else {
+      fd.append(k, String(v));
+    }
+  }
+  return fd;
+}
+
+function run() {
+  // valid 4p
+  let fd = fdFrom({
+    gameDate: '2026-04-06',
+    gameType: '4p',
+    player1: 'A',
+    player2: 'B',
+    player3: 'C',
+    player4: 'D',
+    score1: '250',
+    score2: '100',
+    score3: '-200',
+    score4: '-150',
+    tobiPlayer: 'C',
+    tobashiPlayer: 'D',
+    yakitori1: 'on',
+    notes: 'ok',
+  });
+  let res = validateAndParseMatchForm(fd);
+  assert.ok(res.ok, 'valid 4p should parse');
+  const data = res.data;
+  assert.strictEqual(data.gameDate, '2026-04-06');
+  assert.deepStrictEqual(data.players, ['A', 'B', 'C', 'D']);
+  assert.strictEqual(data.total, 0);
+
+  // duplicate players
+  fd = fdFrom({
+    gameDate: '2026-04-06',
+    gameType: '4p',
+    player1: 'A',
+    player2: 'A',
+    player3: 'C',
+    player4: 'D',
+    score1: '250',
+    score2: '100',
+    score3: '-200',
+    score4: '-150',
+  });
+  res = validateAndParseMatchForm(fd);
+  assert.ok(!res.ok, 'duplicate players should fail');
+  assert.ok(/別の名前/.test(res.message || ''), 'duplicate message');
+
+  // missing tobashi
+  fd = fdFrom({
+    gameDate: '2026-04-06',
+    gameType: '4p',
+    player1: 'A',
+    player2: 'B',
+    player3: 'C',
+    player4: 'D',
+    score1: '250',
+    score2: '100',
+    score3: '-200',
+    score4: '-150',
+    tobiPlayer: 'C',
+  });
+  res = validateAndParseMatchForm(fd);
+  assert.ok(!res.ok, 'missing tobashi should fail');
+  assert.ok(/飛びと飛ばし/.test(res.message || ''), 'tobi/tobashi message');
+
+  // same tobi/tobashi
+  fd = fdFrom({
+    gameDate: '2026-04-06',
+    gameType: '4p',
+    player1: 'A',
+    player2: 'B',
+    player3: 'C',
+    player4: 'D',
+    score1: '250',
+    score2: '100',
+    score3: '-200',
+    score4: '-150',
+    tobiPlayer: 'C',
+    tobashiPlayer: 'C',
+  });
+  res = validateAndParseMatchForm(fd);
+  assert.ok(!res.ok, 'same tobi/tobashi should fail');
+  assert.ok(/同じ/.test(res.message || ''), 'same-player message');
+
+  // out-of-range score
+  fd = fdFrom({
+    gameDate: '2026-04-06',
+    gameType: '4p',
+    player1: 'A',
+    player2: 'B',
+    player3: 'C',
+    player4: 'D',
+    score1: '2000',
+    score2: '0',
+    score3: '0',
+    score4: '-2000',
+  });
+  res = validateAndParseMatchForm(fd);
+  assert.ok(!res.ok, 'out-of-range score should fail');
+  assert.ok(/スコア/.test(res.message || ''), 'score-range message');
+
+  return 0;
+}
+
+try {
+  run();
+  // success
+  // eslint-disable-next-line no-console
+  console.log('validate-match tests passed');
+  process.exit(0);
+} catch (err) {
+  // eslint-disable-next-line no-console
+  console.error(err && err.stack ? err.stack : err);
+  process.exit(1);
+}


### PR DESCRIPTION
* fix(issue-67): add client-side duplicate player validation to MatchEditForm

* fix(issue-67): disable already-selected players in PlayerSelect; pass exclude from forms

* feat(issue-67): disable duplicate tobi/tobashi choices; extract server-side validation to lib/validate-match

* test(issue-67): add unit tests for match validator; run TS test via ts-node/register

<!-- PRテンプレート: 必須ファイルの確認を促します -->

## 概要

変更内容の要約を記載してください。

## 確認事項
- [ ] `.github/copilot-instructions.md` の更新（必要な場合）または存在確認を行った
- [ ] 変更に機密情報が含まれていないことを確認した
- [ ] `npm run build` が成功することを確認した（変更がコードの場合）

## 関連 Issue

Fixes: #
