### PR TITLE
Feature: Issue #117 対局履歴を対局日で絞込み（DB-driven date selection）

### DIFF
--- a/app/matches/page.tsx
+++ b/app/matches/page.tsx
@@ -7,7 +7,7 @@ import DateRangeFilter from "@/components/date-range-filter";
 import { FlashMessage } from "@/components/flash-message";
 import { MatchDeleteButton } from "@/components/match-delete-button";
 import { buttonVariants } from "@/components/ui/button";
-import { fetchMatchResults, type MatchPlayer } from "@/lib/matches";
+import { fetchMatchResults, fetchMatchDates, type MatchPlayer } from "@/lib/matches";
 import Link from "next/link";
 
 export const metadata: Metadata = {
@@ -60,6 +60,7 @@ export default async function MatchesPage({ searchParams }: { searchParams?: Pro
   const end =
     mode === "today" ? todayStr : mode === "thisYear" ? yearEnd : Array.isArray(endRaw) ? endRaw[0] : endRaw;
 
+  const { dates: availableDates, error: datesError } = await fetchMatchDates();
   const { matches, error } = await fetchMatchResults(start, end);
 
   return (
@@ -80,9 +81,15 @@ export default async function MatchesPage({ searchParams }: { searchParams?: Pro
 
           <div className="p-4">
             {/* client-side date filter that sets start/end when '当日' is checked */}
-            <div className="flex items-end gap-4">
+                <div className="flex items-end gap-4">
               <div className="flex-1">
-                <DateRangeFilter initialMode={mode} initialStart={start} initialEnd={end} actionPath="/matches" />
+                <DateRangeFilter
+                  initialMode={mode}
+                  initialStart={start}
+                  initialEnd={end}
+                  actionPath="/matches"
+                  availableDates={datesError ? undefined : availableDates}
+                />
               </div>
             </div>
             {error ? (

--- a/app/matches/page.tsx
+++ b/app/matches/page.tsx
@@ -33,32 +33,51 @@ type SearchParams = { [key: string]: string | string[] | undefined } | undefined
 
 export default async function MatchesPage({ searchParams }: { searchParams?: Promise<SearchParams> }) {
   const params = await (searchParams as Promise<SearchParams> | undefined);
-  const modeRaw = params?.mode;
+  const filterRaw = params?.filter;
+  const modeRaw = params?.mode; // backward compat
   const startRaw = params?.start;
   const endRaw = params?.end;
-  const todayParam = params?.today;
-  const thisYearParam = params?.thisYear;
 
   const todayStr = new Date().toISOString().slice(0, 10);
   const year = new Date().getFullYear();
   const yearStart = `${year}-01-01`;
   const yearEnd = `${year}-12-31`;
 
-  let mode: "today" | "thisYear" | "range" = "thisYear";
-  if (modeRaw) {
-    mode = Array.isArray(modeRaw) ? (modeRaw[0] as "today" | "thisYear" | "range") : (modeRaw as "today" | "thisYear" | "range");
-  } else if (todayParam !== undefined) {
-    mode = "today";
-  } else if (thisYearParam !== undefined) {
-    mode = "thisYear";
+  // resolve filter (new param) with backward compatibility for old mode/start/end
+  let filter: string | undefined;
+  if (filterRaw) filter = Array.isArray(filterRaw) ? (filterRaw[0] as string) : (filterRaw as string);
+  else if (modeRaw) {
+    const m = Array.isArray(modeRaw) ? modeRaw[0] : modeRaw;
+    if (m === "thisYear") filter = "year";
+    else if (m === "today") filter = todayStr;
+    else if (m === "range") filter = "custom";
   } else if (startRaw !== undefined || endRaw !== undefined) {
-    mode = "range";
+    const s = Array.isArray(startRaw) ? (startRaw[0] as string) : (startRaw as string | undefined);
+    const e = Array.isArray(endRaw) ? (endRaw[0] as string) : (endRaw as string | undefined);
+    if (s && e && s === e) filter = s;
+    else filter = "custom";
+  } else {
+    filter = "year";
   }
 
-  const start =
-    mode === "today" ? todayStr : mode === "thisYear" ? yearStart : Array.isArray(startRaw) ? startRaw[0] : startRaw;
-  const end =
-    mode === "today" ? todayStr : mode === "thisYear" ? yearEnd : Array.isArray(endRaw) ? endRaw[0] : endRaw;
+  // compute start/end to pass to data fetch
+  let start: string | undefined;
+  let end: string | undefined;
+  const isDate = (s: string | undefined) => !!s && /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/.test(s);
+  if (filter === "year") {
+    start = yearStart;
+    end = yearEnd;
+  } else if (filter === "custom") {
+    start = Array.isArray(startRaw) ? (startRaw[0] as string | undefined) : (startRaw as string | undefined);
+    end = Array.isArray(endRaw) ? (endRaw[0] as string | undefined) : (endRaw as string | undefined);
+  } else if (isDate(filter)) {
+    start = filter;
+    end = filter;
+  } else {
+    // fallback
+    start = yearStart;
+    end = yearEnd;
+  }
 
   const { dates: availableDates, error: datesError } = await fetchMatchDates();
   const { matches, error } = await fetchMatchResults(start, end);
@@ -84,7 +103,7 @@ export default async function MatchesPage({ searchParams }: { searchParams?: Pro
                 <div className="flex items-end gap-4">
               <div className="flex-1">
                 <DateRangeFilter
-                  initialMode={mode}
+                  initialFilter={filter}
                   initialStart={start}
                   initialEnd={end}
                   actionPath="/matches"

--- a/components/date-range-filter.tsx
+++ b/components/date-range-filter.tsx
@@ -2,57 +2,71 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
-type Mode = "today" | "thisYear" | "range";
-
 type Props = {
-  initialMode?: Mode;
+  // backward compatibility: some pages still pass initialMode
+  initialMode?: "today" | "thisYear" | "range";
+  // new initial filter: 'year' | 'custom' | 'YYYY-MM-DD'
+  initialFilter?: string;
   initialStart?: string | null;
   initialEnd?: string | null;
-  initialToday?: boolean; // backward compatibility
   actionPath?: string;
   availableDates?: string[];
 };
 
-export default function DateRangeFilter({ initialMode, initialStart, initialEnd, initialToday, actionPath, availableDates }: Props) {
-  const computeInitialMode = (): Mode => {
-    if (initialMode === "today" || initialMode === "thisYear" || initialMode === "range") return initialMode as Mode;
-    if (initialToday) return "today";
-    if (initialStart && initialEnd) return "range";
-    return "thisYear";
-  };
+export default function DateRangeFilter({
+  initialMode,
+  initialFilter,
+  initialStart,
+  initialEnd,
+  actionPath,
+  availableDates,
+}: Props) {
+  const today = new Date();
+  const todayStr = today.toISOString().slice(0, 10);
+  const year = today.getFullYear();
+  const yearStart = `${year}-01-01`;
+  const yearEnd = `${year}-12-31`;
 
-  const [mode, setMode] = useState<Mode>(computeInitialMode());
-  const [start, setStart] = useState<string>(initialStart ?? "");
-  const [end, setEnd] = useState<string>(initialEnd ?? "");
-  const endRef = useRef<HTMLInputElement | null>(null);
-
-  const formatDate = (d: Date) => {
-    const y = d.getFullYear();
-    const m = String(d.getMonth() + 1).padStart(2, "0");
-    const day = String(d.getDate()).padStart(2, "0");
-    return `${y}-${m}-${day}`;
-  };
-
-  useEffect(() => {
-    setStart(initialStart ?? "");
-    setEnd(initialEnd ?? "");
-    setMode(computeInitialMode());
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [initialStart, initialEnd, initialMode, initialToday]);
-
-  // when user switches to range mode (or initialMode is range) and no start/end provided,
-  // default inputs to today so user sees today's date immediately
-  useEffect(() => {
-    if (mode === "range" && !start && !end) {
-      const today = formatDate(new Date());
-      setStart(today);
-      setEnd(today);
+  const computeInitial = (): { filter: string; start: string; end: string } => {
+    // explicit new-style initialFilter takes precedence
+    if (initialFilter) {
+      if (initialFilter === "year") return { filter: "year", start: yearStart, end: yearEnd };
+      if (initialFilter === "custom") return { filter: "custom", start: initialStart ?? "", end: initialEnd ?? "" };
+      // assume date string
+      return { filter: initialFilter, start: initialFilter, end: initialFilter };
     }
-    // only run when mode changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mode]);
 
-  // helper to dispatch flash
+    // fallback to old initialMode for backward compatibility
+    if (initialMode) {
+      if (initialMode === "thisYear") return { filter: "year", start: yearStart, end: yearEnd };
+      if (initialMode === "today") return { filter: todayStr, start: todayStr, end: todayStr };
+      if (initialMode === "range") return { filter: "custom", start: initialStart ?? todayStr, end: initialEnd ?? todayStr };
+    }
+
+    // fallback to start/end presence
+    if (initialStart && initialEnd) {
+      if (initialStart === initialEnd) return { filter: initialStart, start: initialStart, end: initialEnd };
+      if (initialStart === yearStart && initialEnd === yearEnd) return { filter: "year", start: yearStart, end: yearEnd };
+      return { filter: "custom", start: initialStart, end: initialEnd };
+    }
+
+    return { filter: "year", start: yearStart, end: yearEnd };
+  };
+
+  const initial = computeInitial();
+  const [filter, setFilter] = useState<string>(initial.filter);
+  const [start, setStart] = useState<string>(initial.start ?? "");
+  const [end, setEnd] = useState<string>(initial.end ?? "");
+  const formRef = useRef<HTMLFormElement | null>(null);
+
+  useEffect(() => {
+    const init = computeInitial();
+    setFilter(init.filter);
+    setStart(init.start ?? "");
+    setEnd(init.end ?? "");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialFilter, initialMode, initialStart, initialEnd]);
+
   const showInvalidDateFlash = useCallback(() => {
     try {
       window.dispatchEvent(new CustomEvent("app:flash", { detail: { type: "invalidDate" } }));
@@ -61,27 +75,46 @@ export default function DateRangeFilter({ initialMode, initialStart, initialEnd,
     }
   }, []);
 
-  function handleStartChange(value: string) {
-    setStart(value);
-    // 開始日をセットしたら終了日を常に同日に上書きし、終了日にフォーカスを移す
-    if (value && mode === "range") {
-      setEnd(value);
-      // 終了日の値をハイライトしてすぐ上書き入力できるようにする
-      setTimeout(() => {
-        endRef.current?.focus();
-        endRef.current?.select?.();
-      }, 0);
-    }
+  function isDateString(s: string) {
+    return /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/.test(s);
   }
 
-  function handleModeChange(newMode: Mode) {
-    setMode(newMode);
-    // セレクトで "任意" を選択したときは常に当日を開始/終了にセットする
-    if (newMode === "range") {
-      const today = formatDate(new Date());
-      setStart(today);
-      setEnd(today);
+  async function handleFilterChange(value: string) {
+    setFilter(value);
+    if (value === "custom") {
+      // show inputs, do not auto-submit
+      const todayStrLocal = new Date().toISOString().slice(0, 10);
+      setStart((prev) => (prev ? prev : todayStrLocal));
+      setEnd((prev) => (prev ? prev : todayStrLocal));
+      return;
     }
+
+    if (value === "year") {
+      setStart(yearStart);
+      setEnd(yearEnd);
+    } else if (isDateString(value)) {
+      setStart(value);
+      setEnd(value);
+    } else {
+      // unknown value -> treat as year
+      setStart(yearStart);
+      setEnd(yearEnd);
+    }
+
+    // auto-submit the form for non-custom selections
+    setTimeout(() => {
+      try {
+        formRef.current?.requestSubmit?.();
+      } catch {
+        formRef.current?.submit();
+      }
+    }, 0);
+  }
+
+  function handleStartChange(value: string) {
+    setStart(value);
+    // keep end in sync when empty
+    if (!end) setEnd(value);
   }
 
   function handleEndChange(value: string) {
@@ -89,46 +122,34 @@ export default function DateRangeFilter({ initialMode, initialStart, initialEnd,
   }
 
   function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
-    if (mode === "range" && start && end && start > end) {
+    if (filter === "custom" && start && end && start > end) {
       e.preventDefault();
       showInvalidDateFlash();
     }
   }
 
+  const hasAvailable = Array.isArray(availableDates) && availableDates.length > 0;
+
   return (
-    <form method="get" action={actionPath} onSubmit={handleSubmit} className="w-full flex flex-col gap-2 mb-2">
+    <form ref={formRef} method="get" action={actionPath} onSubmit={handleSubmit} className="w-full flex flex-col gap-2 mb-2">
       <div className="flex items-center gap-2 w-full flex-wrap">
         <select
-          name="mode"
-          value={mode}
-          onChange={(e) => handleModeChange(e.target.value as Mode)}
-          className="rounded border p-1 text-sm h-10 w-14 sm:w-auto"
+          name="filter"
+          value={filter}
+          onChange={(e) => handleFilterChange(e.target.value)}
+          className="rounded border p-1 text-sm h-10 w-36 sm:w-auto"
         >
-          <option value="thisYear">今年</option>
-          <option value="today">当日</option>
-          <option value="range">任意</option>
+          <option value="year">今年</option>
+          {hasAvailable && availableDates!.map((d) => (
+            <option key={d} value={d}>
+              {d}
+            </option>
+          ))}
+          <option value="custom">任意</option>
         </select>
 
-        {mode === "range" && (
+        {filter === "custom" ? (
           <>
-                  {availableDates && availableDates.length > 0 && (
-                    <div className="flex items-center gap-2">
-                      <label className="text-xs text-emerald-800">開催日</label>
-                      <select
-                        aria-label="開催日"
-                        onChange={(e) => handleStartChange(e.target.value)}
-                        value={start}
-                        className="rounded border p-1 text-sm h-10 w-36"
-                      >
-                        <option value="">選択してください</option>
-                        {availableDates.map((d) => (
-                          <option key={d} value={d}>
-                            {d}
-                          </option>
-                        ))}
-                      </select>
-                    </div>
-                  )}
             <input
               name="start"
               type="date"
@@ -146,7 +167,6 @@ export default function DateRangeFilter({ initialMode, initialStart, initialEnd,
               aria-label="終了日"
               value={end}
               onChange={(e) => handleEndChange(e.target.value)}
-              ref={endRef}
               className="rounded border p-1 text-sm h-10 w-28 sm:w-auto"
             />
 
@@ -157,16 +177,17 @@ export default function DateRangeFilter({ initialMode, initialStart, initialEnd,
               絞込
             </button>
           </>
-        )}
-
-        {mode !== "range" && (
-          <button type="submit" className="ml-2 rounded bg-emerald-600 px-3 py-1 text-sm text-white h-10 flex items-center justify-center">
-            絞込
-          </button>
+        ) : (
+          // keep hidden inputs so CSV export and server can read start/end
+          <>
+            <input name="start" type="hidden" value={start} />
+            <input name="end" type="hidden" value={end} />
+          </>
         )}
       </div>
 
-      {/* CSV button slot kept empty here; pages place CSV button under the table (right-aligned) */}
+      {/* Always include filter in query so server can recognize new-style requests */}
+      <input name="filter" type="hidden" value={filter} />
     </form>
   );
 }

--- a/components/date-range-filter.tsx
+++ b/components/date-range-filter.tsx
@@ -10,9 +10,10 @@ type Props = {
   initialEnd?: string | null;
   initialToday?: boolean; // backward compatibility
   actionPath?: string;
+  availableDates?: string[];
 };
 
-export default function DateRangeFilter({ initialMode, initialStart, initialEnd, initialToday, actionPath }: Props) {
+export default function DateRangeFilter({ initialMode, initialStart, initialEnd, initialToday, actionPath, availableDates }: Props) {
   const computeInitialMode = (): Mode => {
     if (initialMode === "today" || initialMode === "thisYear" || initialMode === "range") return initialMode as Mode;
     if (initialToday) return "today";
@@ -110,6 +111,24 @@ export default function DateRangeFilter({ initialMode, initialStart, initialEnd,
 
         {mode === "range" && (
           <>
+                  {availableDates && availableDates.length > 0 && (
+                    <div className="flex items-center gap-2">
+                      <label className="text-xs text-emerald-800">開催日</label>
+                      <select
+                        aria-label="開催日"
+                        onChange={(e) => handleStartChange(e.target.value)}
+                        value={start}
+                        className="rounded border p-1 text-sm h-10 w-36"
+                      >
+                        <option value="">選択してください</option>
+                        {availableDates.map((d) => (
+                          <option key={d} value={d}>
+                            {d}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  )}
             <input
               name="start"
               type="date"

--- a/design/issue-117-date-filter-design.md
+++ b/design/issue-117-date-filter-design.md
@@ -1,0 +1,98 @@
+# Issue #117 設計: 対局履歴を対局日で絞込み
+
+- Issue: https://github.com/ytr6310zs-jpg/mj-score-manager/issues/117
+- タイトル: 対局履歴 対局日で絞込み
+- 要件メモ: 開催日をDBから取得して選択可能
+
+## 1. 目的
+
+対局履歴画面で、DBに存在する開催日 (`games.date`) を選択して絞込みできるようにする。
+
+## 2. 現状
+
+- `app/matches/page.tsx` は `DateRangeFilter` を使い、`mode=today|thisYear|range` と `start/end` の手入力で絞込みしている。
+- `lib/matches.ts` の `fetchMatchResults(startDate, endDate)` は `games.date` に対して `gte/lte` を適用して取得している。
+- 開催日一覧を返すAPIは存在しない。
+
+## 3. 変更方針
+
+### 3.1 データ取得層
+
+`lib/matches.ts` に開催日一覧取得関数を追加する。
+
+- 追加関数(案): `fetchMatchDates(): Promise<{ dates: string[]; error: string | null }>`
+- 取得元: `games.date`
+- 並び順: 降順(新しい日付を先頭)
+- 返却形式: `YYYY-MM-DD` 文字列配列
+- エラー時: 既存実装と同様に `error` 文字列を返す
+
+備考:
+- 現状の`fetchMatchResults`は維持し、既存URLパラメータ仕様(`mode/start/end`)を壊さない。
+
+### 3.2 画面/API層
+
+`app/matches/page.tsx` で開催日候補を取得し、フィルタUIへ渡す。
+
+- ページロード時に `fetchMatchDates()` を実行
+- 候補を `DateRangeFilter` の新規propsで受け渡し
+- `mode="range"` の場合、既存の入力欄に加え「開催日選択」UIを追加
+
+実装案:
+- 追加props(案):
+  - `availableDates?: string[]`
+  - `selectedDate?: string`
+- `selectedDate` が指定された場合、`start/end` を同日にセットして送信する
+
+### 3.3 フィルタUI
+
+`components/date-range-filter.tsx` を拡張する。
+
+- `mode="range"` 時に、`<select>` で `availableDates` を表示
+- 選択時の動作:
+  - 開催日を選ぶと `start=end=選択日` に同期
+  - 手入力の日付欄は残す(既存互換)
+- 候補が空の場合:
+  - 現行の手入力だけで動作可能にする
+
+UIラベル案:
+- `開催日` (placeholder: `選択してください`)
+
+### 3.4 URLパラメータ互換
+
+新規クエリキーは増やさず、既存の `start/end/mode` に統一する。
+
+- 理由: CSVエクスポートや他画面(統計)の連携を壊さないため
+- 共有URLの挙動を保ち、後方互換を確保
+
+## 4. バリデーションとエラーハンドリング
+
+- `fetchMatchDates` で日付のnull/不正値を除外
+- UIでは `start > end` の既存チェックを維持
+- 開催日一覧取得失敗時は:
+  - セレクトを非表示または無効化
+  - 既存の手入力絞込みは継続可能にする
+
+## 5. 影響範囲
+
+- 変更対象(想定):
+  - `lib/matches.ts`
+  - `app/matches/page.tsx`
+  - `components/date-range-filter.tsx`
+- 非対象:
+  - `app/stats/page.tsx` (今回はIssue文面上、対局履歴のみ)
+  - DBマイグレーション (既存の `games.date` を利用)
+
+## 6. テスト観点
+
+1. 開催日セレクトにDBの日付が降順で表示される
+2. 開催日を選択して送信すると、当該日の対局のみ表示される
+3. 開催日未選択時は既存の手入力レンジ絞込みが機能する
+4. 候補取得失敗時でも画面が壊れず、手入力絞込みは利用できる
+5. 既存の `today/thisYear/range` モード挙動が維持される
+
+## 7. 実装ステップ
+
+1. `lib/matches.ts` に `fetchMatchDates` を追加
+2. `app/matches/page.tsx` で `fetchMatchDates` を呼び出し、`DateRangeFilter` へ渡す
+3. `components/date-range-filter.tsx` に開催日セレクトを追加
+4. 手動確認 + `npm run build` で回帰確認

--- a/design/issue-117-date-filter-design.md
+++ b/design/issue-117-date-filter-design.md
@@ -29,40 +29,71 @@
 備考:
 - 現状の`fetchMatchResults`は維持し、既存URLパラメータ仕様(`mode/start/end`)を壊さない。
 
-### 3.2 画面/API層
+### 3.2 画面/API層（再設計）
 
 `app/matches/page.tsx` で開催日候補を取得し、フィルタUIへ渡す。
 
 - ページロード時に `fetchMatchDates()` を実行
 - 候補を `DateRangeFilter` の新規propsで受け渡し
-- `mode="range"` の場合、既存の入力欄に加え「開催日選択」UIを追加
+- セレクトで選択した値（`filter` パラメータ）を処理:
+  - `filter=year` → 当年を `start/end` にセット
+  - `filter=YYYY-MM-DD` → その日付を `start=end` にセット
+  - `filter=custom` → 手入力の `start/end` を使用
 
 実装案:
 - 追加props(案):
   - `availableDates?: string[]`
-  - `selectedDate?: string`
-- `selectedDate` が指定された場合、`start/end` を同日にセットして送信する
+  - `selectedFilter?: 'year' | 'YYYY-MM-DD' | 'custom'`
+- `selectedFilter` に応じて、セレクト状態と入力欄の表示/非表示を制御
 
-### 3.3 フィルタUI
+### 3.3 フィルタUI（再設計）
 
-`components/date-range-filter.tsx` を拡張する。
+`components/date-range-filter.tsx` をリデザインする。
 
-- `mode="range"` 時に、`<select>` で `availableDates` を表示
-- 選択時の動作:
-  - 開催日を選ぶと `start=end=選択日` に同期
-  - 手入力の日付欄は残す(既存互換)
-- 候補が空の場合:
-  - 現行の手入力だけで動作可能にする
+**主UIは単一セレクト「開催日」に統一：**
 
-UIラベル案:
-- `開催日` (placeholder: `選択してください`)
+```
+[開催日: ▼ 今年▼]  ← セレクト
+```
 
-### 3.4 URLパラメータ互換
+セレクト選択肢:
+1. `今年` ... 現在年（例: 2026-01-01〜2026-12-31）
+2. `実在する開催日1` (YYYY-MM-DD)
+3. `実在する開催日2` ...
+4. `任意` ... カスタム日付入力へ切替
 
-新規クエリキーは増やさず、既存の `start/end/mode` に統一する。
+**動作:**
 
-- 理由: CSVエクスポートや他画面(統計)の連携を壊さないため
-- 共有URLの挙動を保ち、後方互換を確保
+- 選択肢 1〜3 を選ぶ → 即座に `start/end` をセット、フォーム送信
+- `任意` を選ぶ → `start/end` の手入力欄を表示（従来の `mode="range"` と同じUI）
+- 候補が空の場合 → セレクトは非表示、手入力だけで動作可能にする
+
+**廃止対象:**
+- `当日` オプション（実在日が開催日選択肢に含まれるため不要）
+- `mode` の概念（単一セレクト化で不要）
+
+### 3.4 URLパラメータ仕様（再設計）
+
+**新規クエリキー `filter` を導入:**
+
+```
+/matches?filter=year           → 今年を表示
+/matches?filter=2026-04-01     → 2026-04-01 のみ表示
+/matches?filter=custom&start=2026-01-01&end=2026-12-31  → カスタム範囲
+```
+
+**既存 URL との互換:**
+
+当面は既存の `mode/start/end` も受け付け、内部で新形式に変換する（段階的なマイグレーション）。
+
+- `?mode=thisYear` → `filter=year` に読替
+- `?mode=today` → 廃止（対応する `filter` 値なし）
+- `?mode=range&start=X&end=Y` → `filter=custom&start=X&end=Y` に読替
+
+ページロード時の優先順位:
+1. `filter` パラメータがあれば、それを優先
+2. 古い `mode/start/end` があれば、新形式に変換
+3. いずれもなければ、デフォルト `filter=year`
 
 ## 4. バリデーションとエラーハンドリング
 
@@ -82,17 +113,20 @@ UIラベル案:
   - `app/stats/page.tsx` (今回はIssue文面上、対局履歴のみ)
   - DBマイグレーション (既存の `games.date` を利用)
 
-## 6. テスト観点
+## 6. テスト観点（再設計版）
 
-1. 開催日セレクトにDBの日付が降順で表示される
-2. 開催日を選択して送信すると、当該日の対局のみ表示される
-3. 開催日未選択時は既存の手入力レンジ絞込みが機能する
-4. 候補取得失敗時でも画面が壊れず、手入力絞込みは利用できる
-5. 既存の `today/thisYear/range` モード挙動が維持される
+1. 開催日セレクトに「今年」「実在日」「任意」が正しく表示される
+2. 「今年」を選ぶと、年初〜年末の対局が表示される
+3. 実在する開催日を選ぶと、その日の対局のみ表示される
+4. 「任意」を選ぶと、`start/end` 手入力欄が表示される
+5. 手入力で日付範囲を指定して送信すると、該当対局が表示される
+6. 候補取得失敗時でも、セレクトなしで手入力絞込みは利用できる
+7. 既存URL（`?mode=thisYear` など）でもアクセス可能（互換性確認）
 
 ## 7. 実装ステップ
 
-1. `lib/matches.ts` に `fetchMatchDates` を追加
-2. `app/matches/page.tsx` で `fetchMatchDates` を呼び出し、`DateRangeFilter` へ渡す
-3. `components/date-range-filter.tsx` に開催日セレクトを追加
+1. `lib/matches.ts` の `fetchMatchDates` を確認（既実装）
+2. `components/date-range-filter.tsx` を新セレクト構造に全体リデザイン
+3. `app/matches/page.tsx` で URL パラメータ解析を新仕様に対応
 4. 手動確認 + `npm run build` で回帰確認
+5. 既存 URL（`?mode=thisYear` など）でのアクセス動作確認

--- a/lib/matches.ts
+++ b/lib/matches.ts
@@ -253,3 +253,53 @@ export async function fetchMatchResults(startDate?: string, endDate?: string): P
     };
   }
 }
+
+export async function fetchMatchDates(): Promise<{ dates: string[]; error: string | null }> {
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !supabaseKey) {
+    return { dates: [], error: "Supabase 連携用の環境変数が不足しています。" };
+  }
+
+  const supabase = createClient(supabaseUrl, supabaseKey, { auth: { persistSession: false } });
+
+  try {
+    const { data, error } = await supabase.from("games").select("date").order("date", { ascending: false });
+    if (error || !data) {
+      console.error("fetchMatchDates supabase error:", error);
+      return { dates: [], error: "対局日の取得に失敗しました。Supabase の設定を確認してください。" };
+    }
+
+    const rows = data as Array<Record<string, unknown>>;
+    const seen = new Set<string>();
+    const dates: string[] = [];
+
+    for (const r of rows) {
+      const raw = r["date"];
+      if (raw === null || raw === undefined) continue;
+
+      let dateStr = "";
+      if (typeof raw === "string") {
+        dateStr = raw.trim();
+      } else {
+        try {
+          dateStr = new Date(String(raw)).toISOString().slice(0, 10);
+        } catch {
+          continue;
+        }
+      }
+
+      if (!dateStr) continue;
+      if (!seen.has(dateStr)) {
+        seen.add(dateStr);
+        dates.push(dateStr);
+      }
+    }
+
+    return { dates, error: null };
+  } catch (err) {
+    console.error("fetchMatchDates error:", err);
+    return { dates: [], error: "対局日の取得に失敗しました。" };
+  }
+}


### PR DESCRIPTION
## Issue

Closes #117

## 概要

対局履歴画面で、DB に存在する開催日（games.date）を選択して絞込みできるようにしました。

## 変更内容

### 1. lib/matches.ts
- **追加関数**: `fetchMatchDates()` — DB から開催日一覧を降順で取得、重複排除して返却

### 2. components/date-range-filter.tsx
**UI 再設計**:
- 旧型: mode セレクト「今年/当日/任意」+ 条件付き入力欄
- 新型: 単一セレクト「開催日」に統一
  - 選択肢: 「今年」+ 実在開催日一覧（DB から取得）+ 「任意」
  - 「今年」または実在日を選ぶ → 即座に絞込み送信
  - 「任意」を選ぶ → start/end 手入力欄を表示

**機能**:
- 新規 `filter` クエリパラメータ対応
- 既存 `mode/start/end` との後方互換性を維持（段階的マイグレーション対応）
- CSV エクスポートと連携するため、非表示時も `start/end` を hidden input で維持

### 3. app/matches/page.tsx
- `fetchMatchDates()` を呼び出して開催日候補を取得
- URL クエリ解析を新仕様に対応（`filter` パラメータ優先）
  - `?filter=year` → 当年を表示
  - `?filter=YYYY-MM-DD` → 指定日を表示  
  - `?filter=custom&start=X&end=Y` → カスタム範囲を表示
  - 既存 `?mode=thisYear` など → 内部で新形式に自動変換

### 4. design/issue-117-date-filter-design.md
- 再設計内容を設計資料に反映

## テスト項目

- [x] ビルド成功（TypeScript/ESLint）
- [ ] 対局データがある場合、セレクトに「今年」と実在日が表示される（手動確認必要）
- [ ] 「今年」を選ぶと、当年の対局が表示される  
- [ ] 実在日を選ぶと、その日の対局のみ表示される
- [ ] 「任意」を選ぶと、start/end 手入力欄が表示される
- [ ] カスタム範囲で絞込みできる
- [ ] 既存 URL（`?mode=thisYear` など）でアクセス可能（後方互換性）
- [ ] CSV エクスポートが機能する

## 既知事項・注意

### 実装と設計の微細な乖離
設計では「開催日候補が空の場合、セレクトを非表示」と記載していますが、実装では以下のようにしています：
- セレクトは常に表示
- 候補が空でも、「今年」と「任意」は利用可能
- 理由: UI の一貫性と、常に選択肢が存在する状態を保つため（ユーザー体験の向上）

この判断について、レビュー時にご確認ください。必要に応じて、候補空時の非表示ロジックを追加できます。

## 影響範囲

- 変更対象: `lib/matches.ts`、`components/date-range-filter.tsx`、`app/matches/page.tsx`、設計資料
- 非対象: `app/stats/page.tsx`（今後の拡張予定）、DB マイグレーション（既存スキーマ利用）

## Checklist

- [x] コミットメッセージが明確  
- [x] ビルド・lint 確認
- [x] 後方互換性を維持
- [ ] 手動テスト（要レビュー時確認）