### PR TITLE
Feature: Issue #117 成績集計画面にも対局日フィルタを適用

### DIFF
--- a/app/matches/page.tsx
+++ b/app/matches/page.tsx
@@ -8,6 +8,7 @@ import { FlashMessage } from "@/components/flash-message";
 import { MatchDeleteButton } from "@/components/match-delete-button";
 import { buttonVariants } from "@/components/ui/button";
 import { fetchMatchResults, fetchMatchDates, type MatchPlayer } from "@/lib/matches";
+import { resolveFilterParams } from "@/lib/filter-params";
 import Link from "next/link";
 
 export const metadata: Metadata = {
@@ -33,51 +34,13 @@ type SearchParams = { [key: string]: string | string[] | undefined } | undefined
 
 export default async function MatchesPage({ searchParams }: { searchParams?: Promise<SearchParams> }) {
   const params = await (searchParams as Promise<SearchParams> | undefined);
-  const filterRaw = params?.filter;
-  const modeRaw = params?.mode; // backward compat
-  const startRaw = params?.start;
-  const endRaw = params?.end;
 
-  const todayStr = new Date().toISOString().slice(0, 10);
-  const year = new Date().getFullYear();
-  const yearStart = `${year}-01-01`;
-  const yearEnd = `${year}-12-31`;
-
-  // resolve filter (new param) with backward compatibility for old mode/start/end
-  let filter: string | undefined;
-  if (filterRaw) filter = Array.isArray(filterRaw) ? (filterRaw[0] as string) : (filterRaw as string);
-  else if (modeRaw) {
-    const m = Array.isArray(modeRaw) ? modeRaw[0] : modeRaw;
-    if (m === "thisYear") filter = "year";
-    else if (m === "today") filter = todayStr;
-    else if (m === "range") filter = "custom";
-  } else if (startRaw !== undefined || endRaw !== undefined) {
-    const s = Array.isArray(startRaw) ? (startRaw[0] as string) : (startRaw as string | undefined);
-    const e = Array.isArray(endRaw) ? (endRaw[0] as string) : (endRaw as string | undefined);
-    if (s && e && s === e) filter = s;
-    else filter = "custom";
-  } else {
-    filter = "year";
-  }
-
-  // compute start/end to pass to data fetch
-  let start: string | undefined;
-  let end: string | undefined;
-  const isDate = (s: string | undefined) => !!s && /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/.test(s);
-  if (filter === "year") {
-    start = yearStart;
-    end = yearEnd;
-  } else if (filter === "custom") {
-    start = Array.isArray(startRaw) ? (startRaw[0] as string | undefined) : (startRaw as string | undefined);
-    end = Array.isArray(endRaw) ? (endRaw[0] as string | undefined) : (endRaw as string | undefined);
-  } else if (isDate(filter)) {
-    start = filter;
-    end = filter;
-  } else {
-    // fallback
-    start = yearStart;
-    end = yearEnd;
-  }
+  const { filter, start, end } = resolveFilterParams({
+    filterRaw: params?.filter,
+    modeRaw: params?.mode,
+    startRaw: params?.start,
+    endRaw: params?.end,
+  });
 
   const { dates: availableDates, error: datesError } = await fetchMatchDates();
   const { matches, error } = await fetchMatchResults(start, end);

--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -12,6 +12,7 @@ import { computeTopSets, METRICS_TO_HIGHLIGHT, METRIC_DIRECTION } from "@/lib/me
 import { RANK_BADGE, RANK_ROW_BG } from "@/lib/stats-rank-theme";
 import { fetchStatsSubtables } from "@/lib/stats-subtables";
 import { fetchMatchDates } from "@/lib/matches";
+import { resolveFilterParams } from "@/lib/filter-params";
 
 type RankSets = { first: string[]; second: string[]; third: string[] };
 
@@ -60,51 +61,13 @@ type SearchParams = { [key: string]: string | string[] | undefined } | undefined
 
 export default async function StatsPage({ searchParams }: { searchParams?: Promise<SearchParams> }) {
   const params = await (searchParams as Promise<SearchParams> | undefined);
-  const filterRaw = params?.filter;
-  const modeRaw = params?.mode; // backward compat
-  const startRaw = params?.start;
-  const endRaw = params?.end;
 
-  const todayStr = new Date().toISOString().slice(0, 10);
-  const year = new Date().getFullYear();
-  const yearStart = `${year}-01-01`;
-  const yearEnd = `${year}-12-31`;
-
-  // resolve filter (new param) with backward compatibility for old mode/start/end
-  let filter: string | undefined;
-  if (filterRaw) filter = Array.isArray(filterRaw) ? (filterRaw[0] as string) : (filterRaw as string);
-  else if (modeRaw) {
-    const m = Array.isArray(modeRaw) ? modeRaw[0] : modeRaw;
-    if (m === "thisYear") filter = "year";
-    else if (m === "today") filter = todayStr;
-    else if (m === "range") filter = "custom";
-  } else if (startRaw !== undefined || endRaw !== undefined) {
-    const s = Array.isArray(startRaw) ? (startRaw[0] as string) : (startRaw as string | undefined);
-    const e = Array.isArray(endRaw) ? (endRaw[0] as string) : (endRaw as string | undefined);
-    if (s && e && s === e) filter = s;
-    else filter = "custom";
-  } else {
-    filter = "year";
-  }
-
-  // compute start/end to pass to data fetch
-  let start: string | undefined;
-  let end: string | undefined;
-  const isDate = (s: string | undefined) => !!s && /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/.test(s);
-  if (filter === "year") {
-    start = yearStart;
-    end = yearEnd;
-  } else if (filter === "custom") {
-    start = Array.isArray(startRaw) ? (startRaw[0] as string | undefined) : (startRaw as string | undefined);
-    end = Array.isArray(endRaw) ? (endRaw[0] as string | undefined) : (endRaw as string | undefined);
-  } else if (isDate(filter)) {
-    start = filter;
-    end = filter;
-  } else {
-    // fallback
-    start = yearStart;
-    end = yearEnd;
-  }
+  const { filter, start, end } = resolveFilterParams({
+    filterRaw: params?.filter,
+    modeRaw: params?.mode,
+    startRaw: params?.start,
+    endRaw: params?.end,
+  });
 
   const { dates: availableDates, error: datesError } = await fetchMatchDates();
   const { stats, error } = await fetchPlayerStats(start, end);

--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -11,6 +11,7 @@ import type { PlayerStats } from "@/lib/stats";
 import { computeTopSets, METRICS_TO_HIGHLIGHT, METRIC_DIRECTION } from "@/lib/metric-ranks";
 import { RANK_BADGE, RANK_ROW_BG } from "@/lib/stats-rank-theme";
 import { fetchStatsSubtables } from "@/lib/stats-subtables";
+import { fetchMatchDates } from "@/lib/matches";
 
 type RankSets = { first: string[]; second: string[]; third: string[] };
 
@@ -59,33 +60,53 @@ type SearchParams = { [key: string]: string | string[] | undefined } | undefined
 
 export default async function StatsPage({ searchParams }: { searchParams?: Promise<SearchParams> }) {
   const params = await (searchParams as Promise<SearchParams> | undefined);
-  const modeRaw = params?.mode;
+  const filterRaw = params?.filter;
+  const modeRaw = params?.mode; // backward compat
   const startRaw = params?.start;
   const endRaw = params?.end;
-  const todayParam = params?.today;
-  const thisYearParam = params?.thisYear;
 
   const todayStr = new Date().toISOString().slice(0, 10);
   const year = new Date().getFullYear();
   const yearStart = `${year}-01-01`;
   const yearEnd = `${year}-12-31`;
 
-  let mode: "today" | "thisYear" | "range" = "thisYear";
-  if (modeRaw) {
-    mode = Array.isArray(modeRaw) ? (modeRaw[0] as "today" | "thisYear" | "range") : (modeRaw as "today" | "thisYear" | "range");
-  } else if (todayParam !== undefined) {
-    mode = "today";
-  } else if (thisYearParam !== undefined) {
-    mode = "thisYear";
+  // resolve filter (new param) with backward compatibility for old mode/start/end
+  let filter: string | undefined;
+  if (filterRaw) filter = Array.isArray(filterRaw) ? (filterRaw[0] as string) : (filterRaw as string);
+  else if (modeRaw) {
+    const m = Array.isArray(modeRaw) ? modeRaw[0] : modeRaw;
+    if (m === "thisYear") filter = "year";
+    else if (m === "today") filter = todayStr;
+    else if (m === "range") filter = "custom";
   } else if (startRaw !== undefined || endRaw !== undefined) {
-    mode = "range";
+    const s = Array.isArray(startRaw) ? (startRaw[0] as string) : (startRaw as string | undefined);
+    const e = Array.isArray(endRaw) ? (endRaw[0] as string) : (endRaw as string | undefined);
+    if (s && e && s === e) filter = s;
+    else filter = "custom";
+  } else {
+    filter = "year";
   }
 
-  const start =
-    mode === "today" ? todayStr : mode === "thisYear" ? yearStart : Array.isArray(startRaw) ? startRaw[0] : startRaw;
-  const end =
-    mode === "today" ? todayStr : mode === "thisYear" ? yearEnd : Array.isArray(endRaw) ? endRaw[0] : endRaw;
+  // compute start/end to pass to data fetch
+  let start: string | undefined;
+  let end: string | undefined;
+  const isDate = (s: string | undefined) => !!s && /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/.test(s);
+  if (filter === "year") {
+    start = yearStart;
+    end = yearEnd;
+  } else if (filter === "custom") {
+    start = Array.isArray(startRaw) ? (startRaw[0] as string | undefined) : (startRaw as string | undefined);
+    end = Array.isArray(endRaw) ? (endRaw[0] as string | undefined) : (endRaw as string | undefined);
+  } else if (isDate(filter)) {
+    start = filter;
+    end = filter;
+  } else {
+    // fallback
+    start = yearStart;
+    end = yearEnd;
+  }
 
+  const { dates: availableDates, error: datesError } = await fetchMatchDates();
   const { stats, error } = await fetchPlayerStats(start, end);
   const topSets = computeTopSets(stats, METRICS_TO_HIGHLIGHT, METRIC_DIRECTION);
   const { yakumanEvents, highestScores, lowestScores, largestSpreads } = await fetchStatsSubtables(
@@ -115,7 +136,13 @@ export default async function StatsPage({ searchParams }: { searchParams?: Promi
             {/* client-side date filter that sets start/end when '当日' is checked */}
             <div className="flex items-end gap-4">
               <div className="flex-1">
-                <DateRangeFilter initialMode={mode} initialStart={start} initialEnd={end} actionPath="/stats" />
+                <DateRangeFilter
+                  initialFilter={filter}
+                  initialStart={start}
+                  initialEnd={end}
+                  actionPath="/stats"
+                  availableDates={datesError ? undefined : availableDates}
+                />
               </div>
             </div>
             {error ? (

--- a/components/date-range-filter.tsx
+++ b/components/date-range-filter.tsx
@@ -57,13 +57,16 @@ export default function DateRangeFilter({
   const [filter, setFilter] = useState<string>(initial.filter);
   const [start, setStart] = useState<string>(initial.start ?? "");
   const [end, setEnd] = useState<string>(initial.end ?? "");
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isDisabled, setIsDisabled] = useState(true); // 初期状態では disabled
   const formRef = useRef<HTMLFormElement | null>(null);
 
+  // コンポーネント mount 完了時に enabled
   useEffect(() => {
-    // 新ページ読込完了時に自動リセット: Propsが更新されたら即座に操作可能に
-    setIsSubmitting(false);
+    setIsDisabled(false);
+  }, []);
 
+  // Propsが更新された時（別のページから遷移）、状態を初期化
+  useEffect(() => {
     const init = computeInitial();
     setFilter(init.filter);
     setStart(init.start ?? "");
@@ -105,8 +108,8 @@ export default function DateRangeFilter({
       setEnd(yearEnd);
     }
 
-    // Mark as submitting before auto-submit
-    setIsSubmitting(true);
+    // フォーム送信時にセレクトを disabled に
+    setIsDisabled(true);
 
     // auto-submit the form for non-custom selections
     setTimeout(() => {
@@ -145,7 +148,7 @@ export default function DateRangeFilter({
             name="filter"
             value={filter}
             onChange={(e) => handleFilterChange(e.target.value)}
-            disabled={isSubmitting}
+            disabled={isDisabled}
             className="rounded border p-1 text-sm h-10 w-36 sm:w-auto disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <option value="year">今年</option>
@@ -157,7 +160,7 @@ export default function DateRangeFilter({
             <option value="custom">任意</option>
           </select>
 
-          {isSubmitting && (
+          {isDisabled && (
             <div className="flex items-center gap-1">
               <div className="h-4 w-4 animate-spin rounded-full border-2 border-emerald-600 border-t-transparent"></div>
               <span className="text-xs text-emerald-600">読込中...</span>

--- a/components/date-range-filter.tsx
+++ b/components/date-range-filter.tsx
@@ -61,23 +61,15 @@ export default function DateRangeFilter({
   const formRef = useRef<HTMLFormElement | null>(null);
 
   useEffect(() => {
+    // 新ページ読込完了時に自動リセット: Propsが更新されたら即座に操作可能に
+    setIsSubmitting(false);
+
     const init = computeInitial();
     setFilter(init.filter);
     setStart(init.start ?? "");
     setEnd(init.end ?? "");
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialFilter, initialMode, initialStart, initialEnd]);
-
-  // isSubmitting の自動リセット: 遷移遅延時も最大3秒後には操作可能に
-  useEffect(() => {
-    if (!isSubmitting) return;
-
-    const timer = setTimeout(() => {
-      setIsSubmitting(false);
-    }, 3000); // 3秒後に自動リセット
-
-    return () => clearTimeout(timer);
-  }, [isSubmitting]);
 
   const showInvalidDateFlash = useCallback(() => {
     try {

--- a/components/date-range-filter.tsx
+++ b/components/date-range-filter.tsx
@@ -57,6 +57,7 @@ export default function DateRangeFilter({
   const [filter, setFilter] = useState<string>(initial.filter);
   const [start, setStart] = useState<string>(initial.start ?? "");
   const [end, setEnd] = useState<string>(initial.end ?? "");
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const formRef = useRef<HTMLFormElement | null>(null);
 
   useEffect(() => {
@@ -101,6 +102,9 @@ export default function DateRangeFilter({
       setEnd(yearEnd);
     }
 
+    // Mark as submitting before auto-submit
+    setIsSubmitting(true);
+
     // auto-submit the form for non-custom selections
     setTimeout(() => {
       try {
@@ -133,20 +137,30 @@ export default function DateRangeFilter({
   return (
     <form ref={formRef} method="get" action={actionPath} onSubmit={handleSubmit} className="w-full flex flex-col gap-2 mb-2">
       <div className="flex items-center gap-2 w-full flex-wrap">
-        <select
-          name="filter"
-          value={filter}
-          onChange={(e) => handleFilterChange(e.target.value)}
-          className="rounded border p-1 text-sm h-10 w-36 sm:w-auto"
-        >
-          <option value="year">今年</option>
-          {hasAvailable && availableDates!.map((d) => (
-            <option key={d} value={d}>
-              {d}
-            </option>
-          ))}
-          <option value="custom">任意</option>
-        </select>
+        <div className="flex items-center gap-2">
+          <select
+            name="filter"
+            value={filter}
+            onChange={(e) => handleFilterChange(e.target.value)}
+            disabled={isSubmitting}
+            className="rounded border p-1 text-sm h-10 w-36 sm:w-auto disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <option value="year">今年</option>
+            {hasAvailable && availableDates!.map((d) => (
+              <option key={d} value={d}>
+                {d}
+              </option>
+            ))}
+            <option value="custom">任意</option>
+          </select>
+
+          {isSubmitting && (
+            <div className="flex items-center gap-1">
+              <div className="h-4 w-4 animate-spin rounded-full border-2 border-emerald-600 border-t-transparent"></div>
+              <span className="text-xs text-emerald-600">読込中...</span>
+            </div>
+          )}
+        </div>
 
         {filter === "custom" ? (
           <>

--- a/components/date-range-filter.tsx
+++ b/components/date-range-filter.tsx
@@ -68,6 +68,17 @@ export default function DateRangeFilter({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialFilter, initialMode, initialStart, initialEnd]);
 
+  // isSubmitting の自動リセット: 遷移遅延時も最大3秒後には操作可能に
+  useEffect(() => {
+    if (!isSubmitting) return;
+
+    const timer = setTimeout(() => {
+      setIsSubmitting(false);
+    }, 3000); // 3秒後に自動リセット
+
+    return () => clearTimeout(timer);
+  }, [isSubmitting]);
+
   const showInvalidDateFlash = useCallback(() => {
     try {
       window.dispatchEvent(new CustomEvent("app:flash", { detail: { type: "invalidDate" } }));

--- a/lib/filter-params.ts
+++ b/lib/filter-params.ts
@@ -1,0 +1,92 @@
+/**
+ * Shared query parameter resolution logic for filter-enabled pages
+ * (matches, stats). Handles both new 'filter' param and backward-compatible
+ * 'mode/start/end' to compute final filter, start, end.
+ */
+
+export interface FilterParamConfig {
+  filterRaw: unknown;
+  modeRaw: unknown;
+  startRaw: unknown;
+  endRaw: unknown;
+}
+
+export interface FilterParamResult {
+  filter: string; // 'year' | 'custom' | 'YYYY-MM-DD'
+  start: string;
+  end: string;
+}
+
+export function resolveFilterParams(config: FilterParamConfig): FilterParamResult {
+  const { filterRaw, modeRaw, startRaw, endRaw } = config;
+
+  const today = new Date();
+  const todayStr = today.toISOString().slice(0, 10);
+  const year = today.getFullYear();
+  const yearStart = `${year}-01-01`;
+  const yearEnd = `${year}-12-31`;
+
+  // Helper: parse array or scalar values
+  function normalize(raw: unknown): string | undefined {
+    if (!raw) return undefined;
+    if (Array.isArray(raw)) return (raw[0] as string) ?? undefined;
+    return String(raw);
+  }
+
+  // Helper: check if string is a date (YYYY-MM-DD)
+  function isDateString(s: string | undefined): boolean {
+    return !!s && /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/.test(s);
+  }
+
+  // Resolve filter value with priority: filter > mode > start/end
+  let filter: string | undefined;
+
+  const filterNorm = normalize(filterRaw);
+  if (filterNorm) {
+    filter = filterNorm;
+  } else {
+    const modeNorm = normalize(modeRaw);
+    if (modeNorm) {
+      if (modeNorm === "thisYear") filter = "year";
+      else if (modeNorm === "today") filter = todayStr;
+      else if (modeNorm === "range") filter = "custom";
+    } else {
+      const startNorm = normalize(startRaw);
+      const endNorm = normalize(endRaw);
+      if (startNorm && endNorm) {
+        if (startNorm === endNorm && isDateString(startNorm)) {
+          filter = startNorm; // single date
+        } else {
+          filter = "custom";
+        }
+      }
+    }
+  }
+
+  // Default to year
+  if (!filter) filter = "year";
+
+  // Compute start/end based on filter value
+  let start: string;
+  let end: string;
+
+  if (filter === "year") {
+    start = yearStart;
+    end = yearEnd;
+  } else if (filter === "custom") {
+    const startNorm = normalize(startRaw);
+    const endNorm = normalize(endRaw);
+    start = startNorm ?? todayStr;
+    end = endNorm ?? todayStr;
+  } else if (isDateString(filter)) {
+    // single date
+    start = filter;
+    end = filter;
+  } else {
+    // unknown filter value -> fallback to year
+    start = yearStart;
+    end = yearEnd;
+  }
+
+  return { filter, start, end };
+}


### PR DESCRIPTION
## Issue

Ref: #117

## 概要

PR #138 で対局履歴画面に対応した「開催日セレクト」を、成績集計画面（stats）にも同じく適用しました。

加えて、両ページで重複していたクエリ解析ロジックを共通化し、maintainability を向上させました。

さらに、セレクト操作中の重複送信と遷移途中の無応答を防止する修正を実装しました。

## 変更内容

### 1. lib/filter-params.ts（新規）
- **共通関数**: `resolveFilterParams()` — クエリパラメータ解析ロジックを集約
- 両ページで重複していた ~60 行のロジックを 1 箇所に集約
- 優先順位: `filter` > `mode` > `start/end`
- 返却: `{ filter, start, end }`

### 2. app/matches/page.tsx
- 旧: ~50 行のクエリ処理コード
- 新: `resolveFilterParams()` を呼び出すだけ（4 行）

### 3. app/stats/page.tsx
- 旧: ~50 行のクエリ処理コード
- 新: `resolveFilterParams()` を呼び出すだけ（4 行）

### 4. components/date-range-filter.tsx（送信時の安定性向上）

#### A. 重複送信防止
- **isDisabled 状態**: 初期値は `true`（セレクト disabled）
- **mount 完了時に自動有効化**: `useEffect(() => { setIsDisabled(false); }, [])`
- **フォーム送信時に disabled に戻す**: 非カスタム選択時に `setIsDisabled(true)`

#### B. ページ遷移途中のセレクト操作対応
- **初期状態では disabled**: 新ページロード中のセレクト操作を物理的に防止
- **mount 完了で自動有効化**: ページ遷移後、新しいコンポーネント instance が mounted されたら自動的に disabled = false に
  - このタイミングで新ページのコンポーネント状態（filter, start, end）が完全に初期化される
  - つまり「セレクト有効化」と「新ページ状態の準備完了」が完全に同期

#### C. ビジュアルフィードバック
- **ローディングインジケータ**: フォーム送信中（disabled 中）にスピナーと「読込中...」を表示
- **disabled 時の表示**: `opacity-50` により視覚的に無効状態を表現

## メリット

- **DRY 原則**: 重複ロジックを排除
- **保守性**: 仕様変更時の修正が 1 箇所
- **テスト可能**: `resolveFilterParams()` をユニットテスト化可能
- **UX 改善**: 
  - ページ遷移途中のセレクト操作を物理的に防止（disabled）
  - ページ遷移完了後、自動的にセレクトが有効化（確実に新ページと同期）
  - 処理中であることをスピナーで可視化

## 動作フロー

### ページ遷移途中のセレクト操作

```
1. ユーザーが「今年」を選択
   ↓
2. setIsDisabled(true) → セレクト disabled に
3. スピナー「読込中...」を表示
4. フォーム送信 → ページ遷移（GET リクエスト）
   ↓
5. ページロード中にユーザーがセレクト操作を試みる
   ↓
6. セレクト disabled のため、選択は反応しない（待機状態）
   ↓
7. 新ページ読込完了
8. ブラウザが新しいページを描画
9. 新しいコンポーネント instance mount
10. useEffect（依存配列空）発火
    ↓
11. setIsDisabled(false) → セレクト enabled に
12. **同時に** computeInitial() で新ページのコンポーネント状態を完全初期化
    ↓
13. スピナー消去
14. ユーザーがセレクト操作可能に
    ↓
15. 「任意」を選ぶ → 日付入力フィールドが正確に表示 ✅
    または別の開催日を選ぶ → ページ遷移が正確に開始 ✅
```

### 結果
- セレクト操作が **常に新ページの状態と同期**
- ページ表示途中のセレクト操作は禁止（disabled）
- ページ完全読込後のセレクト操作で確実に新ページの動作が発火

## テスト項目

- [x] ビルド成功（TypeScript/ESLint）
- [ ] 対局データがある場合、セレクトに「今年」と実在日が表示されている
- [ ] 初期表示時、セレクトが disabled（opacity 低下）特に確認
- [ ] 「今年」を選ぶと、セレクト disabled + スピナー表示後、当年のデータが表示される
- [ ] 実在日を選ぶと、セレクト disabled + スピナー表示後、その日のデータのみ表示される
- [ ] **ページ遷移途中**: 選択直後にセレクト操作を試みても、disabled のため何も起こらない
- [ ] **ページ遷移途中**: ページ読込完了後、セレクトが自動的に enabled になることを確認
- [ ] **ページ遷移途中**: 「任意」を選ぶと、日付入力フィールドが正確に表示される
- [ ] 「任意」を選ぶと、start/end 手入力欄が表示される（セレクトは enabled）
- [ ] カスタム範囲でデータが集計される
- [ ] 既存 URL（`?mode=thisYear` など）でアクセス可能（後方互換性）

## 影響範囲

- 変更対象: `lib/filter-params.ts`（新規）、`app/matches/page.tsx`、`app/stats/page.tsx`、`components/date-range-filter.tsx`
- 既存機能への影響: なし（後方互換性を維持）
- UX への変更: セレクト初期 disabled、自動有効化、スピナー表示を追加