### PR TITLE
fix: モバイルの期間フィルタ表示を改善

### DIFF
--- a/components/date-range-filter.tsx
+++ b/components/date-range-filter.tsx
@@ -149,7 +149,7 @@ export default function DateRangeFilter({
             value={filter}
             onChange={(e) => handleFilterChange(e.target.value)}
             disabled={isDisabled}
-            className="rounded border p-1 text-sm h-10 w-36 sm:w-auto disabled:opacity-50 disabled:cursor-not-allowed"
+            className="rounded border p-1 text-sm h-10 w-auto disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <option value="year">今年</option>
             {hasAvailable && availableDates!.map((d) => (
@@ -169,7 +169,7 @@ export default function DateRangeFilter({
         </div>
 
         {filter === "custom" ? (
-          <>
+          <div className="flex w-full items-center gap-2 flex-wrap sm:w-auto sm:flex-nowrap">
             <input
               name="start"
               type="date"
@@ -196,7 +196,7 @@ export default function DateRangeFilter({
             >
               絞込
             </button>
-          </>
+          </div>
         ) : (
           // keep hidden inputs so CSV export and server can read start/end
           <>


### PR DESCRIPTION
## 概要
- 期間フィルタのセレクト幅をモバイルでもPCと同じ自動幅に調整
- "任意"選択時の日付範囲フィールドと絞込ボタンを、モバイルでは次行表示に変更
- PCレイアウトでは従来の横並びを維持

## 変更ファイル
- components/date-range-filter.tsx

## 確認
- npm run build: 成功（既存Warningのみ）