### PR TITLE
bug: 印刷画面で '今年' の試合数条件が条件なしになる不整合を修正 (#161)

### DIFF
--- a/app/stats/print/page.tsx
+++ b/app/stats/print/page.tsx
@@ -27,6 +27,9 @@ function buildQueryString(params: PrintSearchParams) {
 export default async function StatsPrintPage({ searchParams }: { searchParams?: Promise<PrintSearchParams> }) {
   // クエリ取得
   const params = await (searchParams as Promise<PrintSearchParams> | undefined);
+  const initialMinGamesRaw = Array.isArray(params?.minGames) ? params?.minGames[0] : params?.minGames;
+  const hasMinGamesParam = initialMinGamesRaw !== undefined;
+
   const { filter, start, end, minGames } = resolveFilterParams({
     filterRaw: params?.filter,
     modeRaw: params?.mode,
@@ -34,13 +37,17 @@ export default async function StatsPrintPage({ searchParams }: { searchParams?: 
     endRaw: params?.end,
     minGamesRaw: params?.minGames,
   });
+
+  // Stats page と同様に、URL に明示的な minGames が無い場合は
+  // filter === 'year' のときにサーバー側で 20 を既定値として使う
+  const effectiveMinGames = typeof minGames === "number" ? minGames : !hasMinGamesParam && filter === "year" ? 20 : undefined;
   // データ取得
-  const { stats } = await fetchPlayerStats(start, end, minGames);
+  const { stats } = await fetchPlayerStats(start, end, effectiveMinGames);
   const { yakumanEvents, highestScores, lowestScores, largestSpreads } = await fetchStatsSubtables(
     start,
     end,
     5,
-    { minGames }
+    { minGames: effectiveMinGames }
   );
   const { matches } = await fetchMatchResults(start, end);
 
@@ -67,7 +74,7 @@ export default async function StatsPrintPage({ searchParams }: { searchParams?: 
     periodLabel = `対象期間: ${start} 〜 ${end}`;
   }
   let minGamesLabel = "試合数条件: 条件なし";
-  if (minGames === 20) minGamesLabel = "試合数条件: 20試合以上";
+  if (effectiveMinGames === 20) minGamesLabel = "試合数条件: 20試合以上";
 
   const queryString = buildQueryString(params);
   const returnUrl = `/stats${queryString ? `?${queryString}` : ""}`;


### PR DESCRIPTION
概要: 成績集計ページは filter==='year' で URL に明示的な minGames がない場合 UI 側で既定値 20 を採用していましたが、印刷ページでは未指定時に条件なしと表示される不整合がありました。本 PR は印刷ページに同じ effectiveMinGames ロジックを適用します.

変更: app/stats/print/page.tsx
ビルド: 確認済み
関連: #161