### PR TITLE
Issue #179: 作業記録ファイルの自動生成と振り返りを導入

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ yarn-error.log*
 # supabase local cli state
 /supabase/.branches/
 /supabase/.temp/
+
+# AI worklog artifacts
+/.worklog/

--- a/README.md
+++ b/README.md
@@ -228,6 +228,39 @@ npm run seed:historical
 
 これらのスクリプトを実行する場合は、Google API 用の環境変数（上に記載）を `.env.local` に追記してください。
 
+## AI作業記録（自動生成と振り返り）
+
+AIエージェント作業のトレーサビリティ向上のため、作業ログを `.worklog/` 配下へ自動生成できます。
+
+基本コマンド:
+
+```bash
+# 作業エントリを追加（当日分のログがなければ自動作成）
+npm run worklog:start -- --summary "入力検証の修正" --decision "検証はzodに統一" --next "stats集計の境界値テスト追加"
+
+# 直近7日を振り返ってレビューを生成
+npm run worklog:review -- --days 7
+```
+
+出力先:
+
+- 日次ログ: `.worklog/logs/YYYY-MM-DD.md`
+- 振り返り: `.worklog/reviews/review-YYYY-MM-DD.md`
+
+主な記録内容:
+
+- 実行日時
+- 現在ブランチ
+- 変更ファイル一覧（`git status --porcelain` ベース）
+- 作業要約（summary）
+- 決定事項（decisions）
+- 次アクション（next actions）
+
+運用注意:
+
+- `.worklog/` は `.gitignore` 済み（ローカル運用前提）
+- APIキー、トークン、個人情報などの機密情報は記録しない
+
 ## 現在の入力ルール
 
 - 3人打ち / 4人打ちの半荘を記録できます

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ AIエージェント作業のトレーサビリティ向上のため、作業ロ
 
 ```bash
 # 作業エントリを追加（当日分のログがなければ自動作成）
-npm run worklog:start -- --summary "入力検証の修正" --decision "検証はzodに統一" --next "stats集計の境界値テスト追加"
+npm run worklog:start -- --summary "入力検証の修正" --reason "不正入力時の再現バグが報告されたため" --decision "検証はzodに統一" --next "stats集計の境界値テスト追加" --done-when "境界値テストが追加されCIで成功する"
 
 # 直近7日を振り返ってレビューを生成
 npm run worklog:review -- --days 7
@@ -253,8 +253,10 @@ npm run worklog:review -- --days 7
 - 現在ブランチ
 - 変更ファイル一覧（`git status --porcelain` ベース）
 - 作業要約（summary）
+- 作業理由（reason）
 - 決定事項（decisions）
 - 次アクション（next actions）
+- 完了条件（done when）
 
 運用注意:
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "check:local-db": "node scripts/check-local-supabase.mjs",
     "dev:local": "npm run check:local-db && next dev",
     "check:local-pages": "node scripts/local-healthcheck.mjs",
-    "verify:local": "npm run dev:local & sleep 3; npm run check:local-pages"
+    "verify:local": "npm run dev:local & sleep 3; npm run check:local-pages",
+    "worklog:start": "node scripts/worklog.mjs start",
+    "worklog:review": "node scripts/worklog.mjs review"
   },
   "dependencies": {
     "@radix-ui/react-label": "^2.1.0",

--- a/scripts/worklog.mjs
+++ b/scripts/worklog.mjs
@@ -37,8 +37,10 @@ function parseArgs(argv) {
   const args = {
     command: "start",
     summary: "",
+    reason: "",
     decisions: [],
     next: [],
+    doneWhen: [],
     tags: [],
     days: 7,
     out: "",
@@ -59,6 +61,12 @@ function parseArgs(argv) {
       continue;
     }
 
+    if (item === "--reason" && next) {
+      args.reason = next;
+      i += 1;
+      continue;
+    }
+
     if (item === "--decision" && next) {
       args.decisions = toArray(next);
       i += 1;
@@ -67,6 +75,12 @@ function parseArgs(argv) {
 
     if (item === "--next" && next) {
       args.next = toArray(next);
+      i += 1;
+      continue;
+    }
+
+    if (item === "--done-when" && next) {
+      args.doneWhen = toArray(next);
       i += 1;
       continue;
     }
@@ -116,7 +130,7 @@ function getChangedFiles() {
   if (!output) return [];
   return output
     .split("\n")
-    .map((line) => line.slice(3).trim())
+    .map((line) => line.replace(/^..\s/, "").trim())
     .filter(Boolean);
 }
 
@@ -129,8 +143,10 @@ function appendWorklog(args) {
   const exists = fs.existsSync(filePath);
 
   const changedFiles = getChangedFiles();
+  const reason = args.reason || "(理由を記載してください)";
   const decisions = args.decisions.length ? args.decisions : ["(必要なら追記)"];
   const nextActions = args.next.length ? args.next : ["(必要なら追記)"];
+  const doneWhen = args.doneWhen.length ? args.doneWhen : ["(完了条件を追記)"];
   const tags = args.tags.length ? args.tags.join(", ") : "(なし)";
   const summary = args.summary || "(作業内容を要約してください)";
 
@@ -153,10 +169,13 @@ function appendWorklog(args) {
     `- tags: ${tags}`,
     `- changed_files: ${changedFiles.length ? changedFiles.join(", ") : "(変更ファイルなし)"}`,
     `- summary: ${summary}`,
+    `- reason: ${reason}`,
     "- decisions:",
     ...decisions.map((d) => `  - ${d}`),
     "- next_actions:",
     ...nextActions.map((n) => `  - ${n}`),
+    "- done_when:",
+    ...doneWhen.map((item) => `  - ${item}`),
     "",
   ].join("\n");
 
@@ -206,8 +225,10 @@ function generateReview(args) {
     : path.join(REPORT_DIR, `review-${reviewDate}.md`);
 
   const summaries = [];
+  const reasons = [];
   const decisions = [];
   const nextActions = [];
+  const doneWhenItems = [];
   const fileCounter = new Map();
   let entryCount = 0;
 
@@ -219,21 +240,34 @@ function generateReview(args) {
       summaries.push(summary);
     }
 
-    const decisionMatches = content.match(/^  - .+$/gm) || [];
-    let inNextActions = false;
+    for (const reason of extractLines(content, "- reason:")) {
+      reasons.push(reason);
+    }
+
+    let currentSection = "";
     for (const line of content.split("\n")) {
       if (line.startsWith("- decisions:")) {
-        inNextActions = false;
+        currentSection = "decisions";
         continue;
       }
       if (line.startsWith("- next_actions:")) {
-        inNextActions = true;
+        currentSection = "next_actions";
+        continue;
+      }
+      if (line.startsWith("- done_when:")) {
+        currentSection = "done_when";
+        continue;
+      }
+      if (line.startsWith("### ")) {
+        currentSection = "";
         continue;
       }
       if (line.startsWith("  - ")) {
-        if (inNextActions) {
+        if (currentSection === "next_actions") {
           nextActions.push(line.slice(4).trim());
-        } else {
+        } else if (currentSection === "done_when") {
+          doneWhenItems.push(line.slice(4).trim());
+        } else if (currentSection === "decisions") {
           decisions.push(line.slice(4).trim());
         }
       }
@@ -245,10 +279,6 @@ function generateReview(args) {
       for (const item of line.split(",").map((v) => v.trim()).filter(Boolean)) {
         fileCounter.set(item, (fileCounter.get(item) || 0) + 1);
       }
-    }
-
-    if (!decisionMatches.length) {
-      // no-op: decisions/next_actions are optional in old logs
     }
   }
 
@@ -266,11 +296,17 @@ function generateReview(args) {
     "## Summary",
     summaries.length ? summaries.map((s) => `- ${s}`).join("\n") : "- (記録なし)",
     "",
+    "## Reason",
+    reasons.length ? reasons.map((r) => `- ${r}`).join("\n") : "- (記録なし)",
+    "",
     "## Decisions",
     decisions.length ? decisions.map((d) => `- ${d}`).join("\n") : "- (記録なし)",
     "",
     "## Next Actions",
     nextActions.length ? nextActions.map((n) => `- ${n}`).join("\n") : "- (記録なし)",
+    "",
+    "## Done When",
+    doneWhenItems.length ? doneWhenItems.map((item) => `- ${item}`).join("\n") : "- (記録なし)",
     "",
     "## Frequently Touched Files",
     topFiles.length ? topFiles.map(([file, count]) => `- ${file} (${count})`).join("\n") : "- (記録なし)",

--- a/scripts/worklog.mjs
+++ b/scripts/worklog.mjs
@@ -1,0 +1,302 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { execSync } from "node:child_process";
+
+const ROOT = process.cwd();
+const WORKLOG_DIR = path.join(ROOT, ".worklog");
+const LOG_DIR = path.join(WORKLOG_DIR, "logs");
+const REPORT_DIR = path.join(WORKLOG_DIR, "reviews");
+
+function ensureDir(dirPath) {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+function now() {
+  return new Date();
+}
+
+function fmtDate(d) {
+  return d.toISOString().slice(0, 10);
+}
+
+function fmtDateTime(d) {
+  return d.toISOString().replace("T", " ").slice(0, 19) + " UTC";
+}
+
+function toArray(value) {
+  if (!value) return [];
+  return value
+    .split(",")
+    .map((v) => v.trim())
+    .filter(Boolean);
+}
+
+function parseArgs(argv) {
+  const args = {
+    command: "start",
+    summary: "",
+    decisions: [],
+    next: [],
+    tags: [],
+    days: 7,
+    out: "",
+  };
+
+  const rest = [...argv];
+  if (rest[0] && !rest[0].startsWith("--")) {
+    args.command = rest.shift();
+  }
+
+  for (let i = 0; i < rest.length; i += 1) {
+    const item = rest[i];
+    const next = rest[i + 1];
+
+    if (item === "--summary" && next) {
+      args.summary = next;
+      i += 1;
+      continue;
+    }
+
+    if (item === "--decision" && next) {
+      args.decisions = toArray(next);
+      i += 1;
+      continue;
+    }
+
+    if (item === "--next" && next) {
+      args.next = toArray(next);
+      i += 1;
+      continue;
+    }
+
+    if (item === "--tags" && next) {
+      args.tags = toArray(next);
+      i += 1;
+      continue;
+    }
+
+    if (item === "--days" && next) {
+      const parsed = Number.parseInt(next, 10);
+      if (Number.isFinite(parsed) && parsed > 0) {
+        args.days = parsed;
+      }
+      i += 1;
+      continue;
+    }
+
+    if (item === "--out" && next) {
+      args.out = next;
+      i += 1;
+    }
+  }
+
+  return args;
+}
+
+function runGit(command) {
+  try {
+    return execSync(command, {
+      cwd: ROOT,
+      stdio: ["ignore", "pipe", "ignore"],
+      encoding: "utf8",
+    }).trim();
+  } catch {
+    return "";
+  }
+}
+
+function getBranch() {
+  return runGit("git branch --show-current") || "unknown";
+}
+
+function getChangedFiles() {
+  const output = runGit("git status --porcelain");
+  if (!output) return [];
+  return output
+    .split("\n")
+    .map((line) => line.slice(3).trim())
+    .filter(Boolean);
+}
+
+function appendWorklog(args) {
+  ensureDir(LOG_DIR);
+
+  const current = now();
+  const day = fmtDate(current);
+  const filePath = path.join(LOG_DIR, `${day}.md`);
+  const exists = fs.existsSync(filePath);
+
+  const changedFiles = getChangedFiles();
+  const decisions = args.decisions.length ? args.decisions : ["(必要なら追記)"];
+  const nextActions = args.next.length ? args.next : ["(必要なら追記)"];
+  const tags = args.tags.length ? args.tags.join(", ") : "(なし)";
+  const summary = args.summary || "(作業内容を要約してください)";
+
+  if (!exists) {
+    const header = [
+      `# Worklog ${day}`,
+      "",
+      "このファイルは AI 作業記録の自動生成で作成されます。",
+      "機密情報（鍵・トークン・個人情報）は記録しないでください。",
+      "",
+      "## Entries",
+      "",
+    ].join("\n");
+    fs.writeFileSync(filePath, header, "utf8");
+  }
+
+  const entry = [
+    `### ${fmtDateTime(current)}`,
+    `- branch: ${getBranch()}`,
+    `- tags: ${tags}`,
+    `- changed_files: ${changedFiles.length ? changedFiles.join(", ") : "(変更ファイルなし)"}`,
+    `- summary: ${summary}`,
+    "- decisions:",
+    ...decisions.map((d) => `  - ${d}`),
+    "- next_actions:",
+    ...nextActions.map((n) => `  - ${n}`),
+    "",
+  ].join("\n");
+
+  fs.appendFileSync(filePath, entry, "utf8");
+  console.log(`Worklog updated: ${path.relative(ROOT, filePath)}`);
+}
+
+function listRecentLogFiles(days) {
+  if (!fs.existsSync(LOG_DIR)) return [];
+
+  const threshold = new Date();
+  threshold.setDate(threshold.getDate() - (days - 1));
+  threshold.setHours(0, 0, 0, 0);
+
+  const files = fs
+    .readdirSync(LOG_DIR)
+    .filter((name) => /^\d{4}-\d{2}-\d{2}\.md$/.test(name))
+    .map((name) => {
+      const date = new Date(`${name.slice(0, 10)}T00:00:00Z`);
+      return {
+        name,
+        date,
+        fullPath: path.join(LOG_DIR, name),
+      };
+    })
+    .filter((item) => item.date >= threshold)
+    .sort((a, b) => a.date - b.date);
+
+  return files;
+}
+
+function extractLines(content, prefix) {
+  return content
+    .split("\n")
+    .filter((line) => line.startsWith(prefix))
+    .map((line) => line.slice(prefix.length).trim())
+    .filter(Boolean);
+}
+
+function generateReview(args) {
+  ensureDir(REPORT_DIR);
+
+  const files = listRecentLogFiles(args.days);
+  const reviewDate = fmtDate(now());
+  const outFile = args.out
+    ? path.resolve(ROOT, args.out)
+    : path.join(REPORT_DIR, `review-${reviewDate}.md`);
+
+  const summaries = [];
+  const decisions = [];
+  const nextActions = [];
+  const fileCounter = new Map();
+  let entryCount = 0;
+
+  for (const file of files) {
+    const content = fs.readFileSync(file.fullPath, "utf8");
+    entryCount += (content.match(/^### /gm) || []).length;
+
+    for (const summary of extractLines(content, "- summary:")) {
+      summaries.push(summary);
+    }
+
+    const decisionMatches = content.match(/^  - .+$/gm) || [];
+    let inNextActions = false;
+    for (const line of content.split("\n")) {
+      if (line.startsWith("- decisions:")) {
+        inNextActions = false;
+        continue;
+      }
+      if (line.startsWith("- next_actions:")) {
+        inNextActions = true;
+        continue;
+      }
+      if (line.startsWith("  - ")) {
+        if (inNextActions) {
+          nextActions.push(line.slice(4).trim());
+        } else {
+          decisions.push(line.slice(4).trim());
+        }
+      }
+    }
+
+    const changedLines = extractLines(content, "- changed_files:");
+    for (const line of changedLines) {
+      if (line === "(変更ファイルなし)") continue;
+      for (const item of line.split(",").map((v) => v.trim()).filter(Boolean)) {
+        fileCounter.set(item, (fileCounter.get(item) || 0) + 1);
+      }
+    }
+
+    if (!decisionMatches.length) {
+      // no-op: decisions/next_actions are optional in old logs
+    }
+  }
+
+  const topFiles = [...fileCounter.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 10);
+
+  const body = [
+    `# Worklog Review (${reviewDate})`,
+    "",
+    `- period_days: ${args.days}`,
+    `- log_files: ${files.length}`,
+    `- entries: ${entryCount}`,
+    "",
+    "## Summary",
+    summaries.length ? summaries.map((s) => `- ${s}`).join("\n") : "- (記録なし)",
+    "",
+    "## Decisions",
+    decisions.length ? decisions.map((d) => `- ${d}`).join("\n") : "- (記録なし)",
+    "",
+    "## Next Actions",
+    nextActions.length ? nextActions.map((n) => `- ${n}`).join("\n") : "- (記録なし)",
+    "",
+    "## Frequently Touched Files",
+    topFiles.length ? topFiles.map(([file, count]) => `- ${file} (${count})`).join("\n") : "- (記録なし)",
+    "",
+  ].join("\n");
+
+  ensureDir(path.dirname(outFile));
+  fs.writeFileSync(outFile, body, "utf8");
+  console.log(`Review generated: ${path.relative(ROOT, outFile)}`);
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (args.command === "start" || args.command === "touch") {
+    appendWorklog(args);
+    return;
+  }
+
+  if (args.command === "review") {
+    generateReview(args);
+    return;
+  }
+
+  console.error("Unknown command. Use: start|touch|review");
+  process.exitCode = 1;
+}
+
+main();


### PR DESCRIPTION
## 概要
- 作業記録を日次で自動追記する仕組みを追加
- 直近N日を対象に振り返りレポートを生成する仕組みを追加
- README に運用手順を追加

## 変更内容
- scripts/worklog.mjs を追加
  - start|touch: .worklog/logs/YYYY-MM-DD.md に記録を追記
  - review: .worklog/reviews/review-YYYY-MM-DD.md を生成
- package.json
  - worklog:start
  - worklog:review
- .gitignore
  - /.worklog/ を追加
- README.md
  - AI作業記録（自動生成と振り返り）の利用手順を追記

## 動作確認
- npm run worklog:start -- --summary "worklog機能の初期導入" --decision "ログはローカル保存にする" --next "チーム運用ルールを追記する"
- npm run worklog:review -- --days 7
- npm run build ✅

補足:
- build 時に既存 Warning 1件あり（lib/stats-rank-theme.ts）。今回変更起因ではありません。

## 関連Issue
- Closes #179
