### PR TITLE
fix(ci): route staging DB jobs to Staging environment

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -24,7 +24,7 @@ jobs:
     uses: ./.github/workflows/migrate-common.yml
     with:
       target: "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.target || 'staging' }}"
-      environment_name: "${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'prod') && 'Production – mj-score-manager-tfvp' || 'Preview – mj-score-manager-tfvp' }}"
+      environment_name: "${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'prod') && 'Production – mj-score-manager-tfvp' || (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'preview') && 'Preview – mj-score-manager-tfvp' || 'Staging' }}"
       allow_repair: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'prod' && false || true }}
       supabase_cli_version: '2.84.2'
     secrets: inherit

--- a/.github/workflows/reset-and-seed-players.yml
+++ b/.github/workflows/reset-and-seed-players.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   reset_and_seed:
     runs-on: ubuntu-latest
-    environment: "${{ github.event.inputs.target == 'prod' && 'Production – mj-score-manager-tfvp' || 'Preview – mj-score-manager-tfvp' }}"
+    environment: "${{ github.event.inputs.target == 'prod' && 'Production – mj-score-manager-tfvp' || 'Staging' }}"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/supabase-keepalive.yml
+++ b/.github/workflows/supabase-keepalive.yml
@@ -22,7 +22,7 @@ jobs:
     if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.target == 'all' || github.event.inputs.target == 'staging' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    environment: "Preview – mj-score-manager-tfvp"
+    environment: "Staging"
 
     steps:
       - name: Ping Supabase DB (staging)


### PR DESCRIPTION
## 設計概要
- stg migrate 失敗ログ（run: 25143718692 / job: 73698961916）を調査し、SQL migration ではなく DB 接続解決段階で失敗していることを確認。
- 失敗時の実行コンテキストが target=staging なのに environment_name=Preview – mj-score-manager-tfvp だったため、環境シークレット解決先の不整合を根本原因として修正。

## 実装概要
- .github/workflows/migrate.yml
  - target=staging 時の environment_name を Staging に変更
  - target=preview は従来通り Preview – mj-score-manager-tfvp
  - target=prod は Production – mj-score-manager-tfvp
- .github/workflows/reset-and-seed-players.yml
  - staging 実行時の environment を Staging に変更
- .github/workflows/supabase-keepalive.yml
  - keepalive-staging の environment を Staging に変更

## 実行した検証コマンドと結果
- gh run view 25143718692 --job 73698961916 --log-failed : 失敗原因を確認（tenant/user ... not found）
- npm run build : 成功

## 手動動作確認の内容
- ワークフローファイル差分を確認し、staging ルートが Preview ではなく Staging 環境へ到達することを確認。

## 既知の未解決事項
- GitHub の Staging 環境シークレット STAGING_DATABASE_URL 自体が古い場合は、この PR マージ後も接続失敗が残る可能性があります。必要に応じてシークレット値の更新をお願いします。
