### PR TITLE
fix(ci): align staging env to existing Preview policy

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -24,7 +24,7 @@ jobs:
     uses: ./.github/workflows/migrate-common.yml
     with:
       target: "${{ github.event_name == 'workflow_dispatch' && github.event.inputs.target || 'staging' }}"
-      environment_name: "${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'prod') && 'Production – mj-score-manager-tfvp' || (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'preview') && 'Preview – mj-score-manager-tfvp' || 'Staging' }}"
+      environment_name: "${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'prod') && 'Production – mj-score-manager-tfvp' || 'Preview – mj-score-manager-tfvp' }}"
       allow_repair: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'prod' && false || true }}
       supabase_cli_version: '2.84.2'
     secrets: inherit

--- a/.github/workflows/reset-and-seed-players.yml
+++ b/.github/workflows/reset-and-seed-players.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   reset_and_seed:
     runs-on: ubuntu-latest
-    environment: "${{ github.event.inputs.target == 'prod' && 'Production – mj-score-manager-tfvp' || 'Staging' }}"
+    environment: "${{ github.event.inputs.target == 'prod' && 'Production – mj-score-manager-tfvp' || 'Preview – mj-score-manager-tfvp' }}"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/supabase-keepalive.yml
+++ b/.github/workflows/supabase-keepalive.yml
@@ -22,7 +22,7 @@ jobs:
     if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.target == 'all' || github.event.inputs.target == 'staging' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    environment: "Staging"
+    environment: "Preview – mj-score-manager-tfvp"
 
     steps:
       - name: Ping Supabase DB (staging)


### PR DESCRIPTION
## 設計概要
- 今回は既存運用（staging: Preview – mj-score-manager-tfvp, prod: Production – mj-score-manager-tfvp）を優先する方針に合わせる。
- environment 名の見直しは影響範囲が広いため、別Issueで段階的に実施する前提。

## 実装概要
- .github/workflows/migrate.yml
  - staging 実行時の environment_name を Preview – mj-score-manager-tfvp に戻した
- .github/workflows/reset-and-seed-players.yml
  - staging 実行時の environment を Preview – mj-score-manager-tfvp に戻した
- .github/workflows/supabase-keepalive.yml
  - keepalive-staging の environment を Preview – mj-score-manager-tfvp に戻した

## 実行した検証コマンドと結果
- npm run build: 成功

## 手動動作確認の内容
- workflow 差分を確認し、staging の environment が既存ポリシー通り Preview を参照することを確認。

## 既知の未解決事項
- 失敗ログの tenant/user not found は接続先 URL 側の問題である可能性が高い。Preview 環境の STAGING_DATABASE_URL が最新 Supabase project ref を指しているかは別途確認が必要。
