### PR TITLE
fix(issue-184): login OTP-only display + user-add refresh

### DIFF
--- a/app/login/actions.ts
+++ b/app/login/actions.ts
@@ -38,6 +38,7 @@ export async function loginAction(
   const totpSecret = totpSecretRaw && totpSecretRaw !== "MFA_TOTP_SECRET" ? totpSecretRaw : "";
   const cookieStore = await cookies();
   const preauthUser = String(cookieStore.get(PREAUTH_COOKIE_NAME)?.value ?? "").trim();
+  const isOtpOnlyStep = Boolean(_prevState?.requireOtp && otp.trim() && !password);
 
   const handleInvalidCredential = () => {
     const currentFailures = Number(cookieStore.get(LOGIN_FAILURE_COOKIE_NAME)?.value ?? "0");
@@ -73,7 +74,7 @@ export async function loginAction(
     return null;
   };
 
-  if (!userId || (!(_prevState?.requireOtp) && !password)) {
+  if (!userId || (!password && !isOtpOnlyStep)) {
     return { error: "ユーザーIDとパスワードを入力してください。", message: null, requireOtp: false, userId };
   }
 
@@ -99,31 +100,33 @@ export async function loginAction(
     return { error: "ユーザーIDまたはパスワードが一致しません。", message: null, requireOtp: false, userId };
   }
 
-  const matched = await compare(password, user.passwordHash);
-  if (!matched) {
-    const lock = handleInvalidCredential();
-    if (lock) {
-      return lock;
+  if (!isOtpOnlyStep) {
+    const matched = await compare(password, user.passwordHash);
+    if (!matched) {
+      const lock = handleInvalidCredential();
+      if (lock) {
+        return lock;
+      }
+      return { error: "ユーザーIDまたはパスワードが一致しません。", message: null, requireOtp: false, userId };
     }
-    return { error: "ユーザーIDまたはパスワードが一致しません。", message: null, requireOtp: false, userId };
-  }
 
-  if (totpSecret && !otp.trim()) {
-    // Mark pre-authenticated user for short time so next submission can be OTP-only.
-    cookieStore.set(PREAUTH_COOKIE_NAME, String(userId), {
-      httpOnly: true,
-      sameSite: "lax",
-      secure: process.env.NODE_ENV === "production",
-      path: "/",
-      maxAge: 60 * 5,
-    });
+    if (totpSecret && !otp.trim()) {
+      // Mark pre-authenticated user for short time so next submission can be OTP-only.
+      cookieStore.set(PREAUTH_COOKIE_NAME, String(userId), {
+        httpOnly: true,
+        sameSite: "lax",
+        secure: process.env.NODE_ENV === "production",
+        path: "/",
+        maxAge: 60 * 5,
+      });
 
-    return {
-      error: null,
-      message: "パスワード認証に成功しました。ワンタイムパスワードを入力してください。",
-      requireOtp: true,
-      userId,
-    };
+      return {
+        error: null,
+        message: "パスワード認証に成功しました。ワンタイムパスワードを入力してください。",
+        requireOtp: true,
+        userId,
+      };
+    }
   }
 
   if (totpSecret) {

--- a/app/login/actions.ts
+++ b/app/login/actions.ts
@@ -10,6 +10,7 @@ import {
   LOGIN_LOCK_SECONDS,
   MAX_LOGIN_FAILURES,
   SESSION_MAX_AGE_SECONDS,
+  PREAUTH_COOKIE_NAME,
   createAuthToken,
 } from "@/lib/auth";
 import { fetchUserByUserId } from "@/lib/users";
@@ -36,6 +37,7 @@ export async function loginAction(
   const totpSecretRaw = String(process.env.MFA_TOTP_SECRET ?? "").trim();
   const totpSecret = totpSecretRaw && totpSecretRaw !== "MFA_TOTP_SECRET" ? totpSecretRaw : "";
   const cookieStore = await cookies();
+  const preauthUser = String(cookieStore.get(PREAUTH_COOKIE_NAME)?.value ?? "").trim();
 
   const handleInvalidCredential = () => {
     const currentFailures = Number(cookieStore.get(LOGIN_FAILURE_COOKIE_NAME)?.value ?? "0");
@@ -71,7 +73,7 @@ export async function loginAction(
     return null;
   };
 
-  if (!userId || !password) {
+  if (!userId || (!(_prevState?.requireOtp) && !password)) {
     return { error: "ユーザーIDとパスワードを入力してください。", message: null, requireOtp: false, userId };
   }
 
@@ -107,6 +109,15 @@ export async function loginAction(
   }
 
   if (totpSecret && !otp.trim()) {
+    // Mark pre-authenticated user for short time so next submission can be OTP-only.
+    cookieStore.set(PREAUTH_COOKIE_NAME, String(userId), {
+      httpOnly: true,
+      sameSite: "lax",
+      secure: process.env.NODE_ENV === "production",
+      path: "/",
+      maxAge: 60 * 5,
+    });
+
     return {
       error: null,
       message: "パスワード認証に成功しました。ワンタイムパスワードを入力してください。",
@@ -115,13 +126,25 @@ export async function loginAction(
     };
   }
 
-  if (totpSecret && !verifyTotpCode(otp, totpSecret)) {
-    const lock = handleInvalidCredential();
-    if (lock) {
-      return lock;
+  if (totpSecret) {
+    // For OTP verification require a recent preauth cookie matching the user.
+    if (!preauthUser || preauthUser !== userId) {
+      const lock = handleInvalidCredential();
+      if (lock) {
+        return lock;
+      }
+
+      return { error: "セッションが期限切れました。再度ID/パスワードで認証してください。", message: null, requireOtp: false, userId };
     }
 
-    return { error: "ワンタイムパスワードが一致しません。", message: null, requireOtp: true, userId };
+    if (!verifyTotpCode(otp, totpSecret)) {
+      const lock = handleInvalidCredential();
+      if (lock) {
+        return lock;
+      }
+
+      return { error: "ワンタイムパスワードが一致しません。", message: null, requireOtp: true, userId };
+    }
   }
 
   const token = await createAuthToken({
@@ -133,6 +156,7 @@ export async function loginAction(
 
   cookieStore.delete(LOGIN_FAILURE_COOKIE_NAME);
   cookieStore.delete(LOGIN_LOCK_COOKIE_NAME);
+  cookieStore.delete(PREAUTH_COOKIE_NAME);
   cookieStore.set(AUTH_COOKIE_NAME, token, {
     httpOnly: true,
     sameSite: "lax",

--- a/app/login/login-form.tsx
+++ b/app/login/login-form.tsx
@@ -26,10 +26,14 @@ export function LoginForm() {
       </CardHeader>
       <CardContent>
         <form action={formAction} className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="userId">ユーザーID</Label>
-            <Input id="userId" name="userId" type="text" required defaultValue={state.userId} />
-          </div>
+          {!state.requireOtp ? (
+            <div className="space-y-2">
+              <Label htmlFor="userId">ユーザーID</Label>
+              <Input id="userId" name="userId" type="text" required defaultValue={state.userId} />
+            </div>
+          ) : (
+            <input type="hidden" name="userId" value={state.userId} />
+          )}
           <div className="space-y-2">
             {!state.requireOtp ? (
               <>

--- a/app/login/login-form.tsx
+++ b/app/login/login-form.tsx
@@ -31,8 +31,12 @@ export function LoginForm() {
             <Input id="userId" name="userId" type="text" required defaultValue={state.userId} />
           </div>
           <div className="space-y-2">
-            <Label htmlFor="password">パスワード</Label>
-            <Input id="password" name="password" type="password" required />
+            {!state.requireOtp ? (
+              <>
+                <Label htmlFor="password">パスワード</Label>
+                <Input id="password" name="password" type="password" required />
+              </>
+            ) : null}
           </div>
           {state.requireOtp ? (
             <div className="space-y-2">

--- a/app/user-actions.ts
+++ b/app/user-actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { hash } from "bcryptjs";
+import { revalidatePath } from "next/cache";
 
 import { canAccessAdmin } from "@/lib/authorization";
 import { getCurrentSession } from "@/lib/session";
@@ -107,6 +108,13 @@ export async function addUserAction(
   if (error) {
     console.error("addUserAction insert error:", error);
     return { success: false, message: "ユーザーの追加に失敗しました。" };
+  }
+
+  try {
+    // Ensure the admin users page is revalidated so the new user appears immediately.
+    revalidatePath("/admin/users");
+  } catch (e) {
+    // ignore revalidate errors
   }
 
   return { success: true, message: "ユーザーを追加しました。" };

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,6 +1,7 @@
 export const AUTH_COOKIE_NAME = "mj_access";
 export const LOGIN_FAILURE_COOKIE_NAME = "mj_login_failures";
 export const LOGIN_LOCK_COOKIE_NAME = "mj_login_locked_until";
+export const PREAUTH_COOKIE_NAME = "mj_preauth_user";
 export const SESSION_MAX_AGE_SECONDS = 60 * 60;
 export const MAX_LOGIN_FAILURES = 5;
 export const LOGIN_LOCK_SECONDS = 60 * 5;

--- a/test/e2e/ui/admin-navigation.spec.ts
+++ b/test/e2e/ui/admin-navigation.spec.ts
@@ -1,6 +1,5 @@
 import { expect, test, type Page } from "@playwright/test";
-import { TOTP } from "otplib";
-const totp = new TOTP();
+import { generate } from "otplib";
 
 const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || "http://localhost:3000";
 const E2E_LOGIN_USER_ID = process.env.E2E_LOGIN_USER_ID || "admin";
@@ -20,8 +19,8 @@ async function loginAsAdmin(page: Page) {
   if (TOTP_SECRET) {
     const otpInput = page.locator('input[name="otp"], input#otp').first();
     await expect(otpInput).toBeVisible({ timeout: 10000 });
-    totp.options = { digits: 6, period: 30 };
-    await otpInput.fill(totp.generate(TOTP_SECRET));
+    const code = await generate({ secret: TOTP_SECRET, digits: 6, period: 30 });
+    await otpInput.fill(code);
     await loginButton.click();
   }
 

--- a/test/e2e/ui/admin-navigation.spec.ts
+++ b/test/e2e/ui/admin-navigation.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, type Page } from "@playwright/test";
-import { totp } from "otplib";
+import { TOTP } from "otplib";
+const totp = new TOTP();
 
 const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || "http://localhost:3000";
 const E2E_LOGIN_USER_ID = process.env.E2E_LOGIN_USER_ID || "admin";

--- a/test/e2e/ui/score-entry.spec.ts
+++ b/test/e2e/ui/score-entry.spec.ts
@@ -1,5 +1,6 @@
 import { expect, Page, test } from "@playwright/test";
-import { totp } from "otplib";
+import { TOTP } from "otplib";
+const totp = new TOTP();
 import { createClient } from "@supabase/supabase-js";
 
 /**

--- a/test/e2e/ui/score-entry.spec.ts
+++ b/test/e2e/ui/score-entry.spec.ts
@@ -1,6 +1,5 @@
 import { expect, Page, test } from "@playwright/test";
-import { TOTP } from "otplib";
-const totp = new TOTP();
+import { generate } from "otplib";
 import { createClient } from "@supabase/supabase-js";
 
 /**
@@ -132,11 +131,8 @@ async function loginIfNeeded(page: Page) {
   if (TOTP_SECRET) {
     const otpInput = page.locator('input[name="otp"], input#otp').first();
     await expect(otpInput).toBeVisible({ timeout: 10000 });
-    totp.options = {
-      digits: 6,
-      period: 30,
-    };
-    await otpInput.fill(totp.generate(TOTP_SECRET));
+    const code = await generate({ secret: TOTP_SECRET, digits: 6, period: 30 });
+    await otpInput.fill(code);
     await loginButton.click();
   }
 


### PR DESCRIPTION
Fixes: \n- Show only OTP input after successful ID/PW and avoid re-requesting password (uses a short-lived preauth cookie).\n- Revalidate /admin/users after adding a user so newly added users appear immediately.\n\nSee changes in: lib/auth.ts, app/login/login-form.tsx, app/login/actions.ts, app/user-actions.ts