### PR TITLE
fix(worklog): remove stray opening brace left after generateReview deletion

### DIFF
--- a/scripts/worklog.mjs
+++ b/scripts/worklog.mjs
@@ -215,7 +215,6 @@ function extractLines(content, prefix) {
     .filter(Boolean);
 }
 
-function generateReview(args) {
 // `generateReview` removed. Delegate `review` command to `scripts/summary-worklog.mjs`.
 
 function main() {


### PR DESCRIPTION
## 設計概要
`generateReview` 削除時に開きブレース `{` が残存し、`worklog.mjs` が SyntaxError で起動不能になっていた不具合の修正です。

## Spec
軽微な1行修正のため PR 本文内に記載します。

## 実装概要
- `scripts/worklog.mjs`: `generateReview(args) {` の開きブレースのみを削除（関数本体は前 PR で削除済みのコメント行のみ残存していた）。

## 実行した検証コマンドと結果
- `node scripts/worklog.mjs start --summary test` → 成功（Worklog updated）
- `npm run build` → 成功

## 手動動作確認の内容
- `npm run worklog:generate` が正常終了することを確認。

## 既知の未解決事項
なし。

関連 Issue: #179