### PR TITLE
feat: increase session timeout to 12 hours (#211)

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -2,7 +2,7 @@ export const AUTH_COOKIE_NAME = "mj_access";
 export const LOGIN_FAILURE_COOKIE_NAME = "mj_login_failures";
 export const LOGIN_LOCK_COOKIE_NAME = "mj_login_locked_until";
 export const PREAUTH_COOKIE_NAME = "mj_preauth_user";
-export const SESSION_MAX_AGE_SECONDS = 60 * 60;
+export const SESSION_MAX_AGE_SECONDS = 60 * 60 * 12;
 export const MAX_LOGIN_FAILURES = 5;
 export const LOGIN_LOCK_SECONDS = 60 * 5;
 


### PR DESCRIPTION
## 設計概要
セッションのタイムアウト時間を 1 時間から 12 時間に延長する。ユーザーが長時間ブラウザを開いたままでもセッションが切れず、より良いUXを提供する。

## 実装概要
- **ファイル**: `lib/auth.ts`
- **変更内容**: `SESSION_MAX_AGE_SECONDS` を `60 * 60` (1h) から `60 * 60 * 12` (12h) に更新
- **影響範囲**: JWT トークン生成時の有効期限（`createAuthToken()` 内で使用）

## 実行した検証コマンドと結果
```bash
npm run build
```
✅ Build succeeded (no errors, warnings only from unrelated code)

## 手動動作確認の内容
変更はセッション有効期限の定数定義のみであるため、以下を確認：
1. ビルドが成功することを確認 ✅
2. トークン生成ロジックに変更がないことを確認（JWT expiration time は SESSION_MAX_AGE_SECONDS を参照）✅
3. 既存のセッション検証ロジックに影響がないことを確認 ✅

## 既知の未解決事項
なし

## Worklog
- Updated `lib/auth.ts`: Changed `SESSION_MAX_AGE_SECONDS` from 1h to 12h
- Build verified: `npm run build` passed successfully

## Issue
Closes #211