### PR TITLE
fix: unify yakuman data source in match edit form with score form (#209)

### DIFF
--- a/.specify/specs/209-212-backend-p1/spec.md
+++ b/.specify/specs/209-212-backend-p1/spec.md
@@ -1,0 +1,110 @@
+---
+title: Issue-209/210/211/212 — Backend P1 実装計画
+owner: @copilot
+created: 2026-05-04
+status: Draft
+related_issues:
+  - 209
+  - 210
+  - 211
+  - 212
+---
+
+背景
+--
+P1 として設定した Backend & Logic の 4 Issue を 5/10 までに完了する。
+- #209: 数え役満が対局履歴編集画面で選択できない
+- #210: 飛ばし複数人対応（2人飛ばし=2件カウント）
+- #211: セッションタイムアウト 12 時間化
+- #212: 試合数フィルタ漏れ修正（/stats と /stats/print の1つ目別表）
+
+確認済み事項
+--
+- 本番 DB の `yakuman_types` に数え役満は存在する。
+- スコア入力画面では数え役満を選択できるが、対局履歴編集画面では選択できない。
+- 複数飛ばし保存形式は `tobashi_player_ids`（JSON 配列）を採用する。
+- 複数飛ばしの集計は「2人飛ばし = 2件」で計上する。
+- PDF 出力は「上段=画面フィルタ準拠」「下段=今年20試合以上固定」の2段構成を維持する。
+
+目的
+--
+1. 編集画面を含め、役満選択の挙動を画面間で一致させる。
+2. 複数飛ばしを入力・保存・集計まで一貫対応する。
+3. セッション期限を 12 時間に統一する。
+4. 試合数フィルタが別表にも漏れなく適用されるようにする。
+
+非目的
+--
+- Frontend & UI マイルストーン（#213-#215）の実装。
+- PDF 下段（今年20試合以上固定）の仕様変更。
+
+短期実装計画（3〜6ステップ）
+--
+
+1. 先行修正: #211 セッション期限 12 時間化
+- 作業: `lib/auth.ts` の `SESSION_MAX_AGE_SECONDS` を 1h から 12h へ変更。
+- 成果物: `lib/auth.ts` の最小差分。
+- 検証: `npm run build`。
+- ブランチ: `feature/issue-211-session-timeout-12h`
+
+2. 不具合修正: #209 編集画面の役満選択同期
+- 作業: 対局履歴編集画面の役満データ取得経路を、スコア入力画面と同じ `/api/yakumans` ベースに統一。
+- 成果物: `components/match-edit-form.tsx`（必要なら共通 hook 側）
+- 検証:
+  - 手動: スコア入力画面と編集画面の両方で「数え役満」を選択可能。
+  - `npm run build`
+- ブランチ: `feature/issue-209-kazoe-yakuman-edit-fix`
+
+3. ロジック修正: #212 別表の minGames フィルタ漏れ解消
+- 作業: `lib/stats-subtables.js` の別表生成で `eligiblePlayers` を点差表にも適用。上段は URL フィルタ準拠、下段は 20 試合固定の現仕様を維持。
+- 成果物: `lib/stats-subtables.js`（必要なら型定義）
+- 検証:
+  - 手動: minGames=20 で 19 試合のプレイヤーが上段別表に出ない。
+  - 境界確認: 19/20/21
+  - `npm run build`
+- ブランチ: `feature/issue-212-min-games-filter-fix`
+
+4. データ拡張: #210 tobashi_player_ids 追加（互換維持）
+- 作業: `games` に `tobashi_player_ids`（JSON 配列）を追加し、既存 `tobashi_player`/`tobashi_player_id` は後方互換で維持。
+- 成果物: `supabase/migrations/*_add_tobashi_player_ids.sql`、保存/読取ロジックの更新。
+- 検証:
+  - 手動: 2人飛ばしを登録・編集できる。
+  - `npm run build`
+- ブランチ: `feature/issue-210-multi-tobashi`
+
+5. UI 反映: #210 チェックボックス入力対応
+- 作業: スコア入力画面と対局履歴編集画面の飛ばし UI をチェックボックス化（A案）。
+- 成果物: `components/score-form.tsx`、`components/match-edit-form.tsx`。
+- 検証:
+  - 手動: 複数選択が可能、保存後の再編集で選択状態が復元。
+  - `npm run build`
+- ブランチ: `feature/issue-210-multi-tobashi`
+
+6. 集計整合: #210 のカウント仕様反映
+- 作業: 複数飛ばしを「人数分カウント」へ統一（2人飛ばし=2件）。
+- 成果物: 集計ロジック更新（該当 `lib/*`）。
+- 検証:
+  - 手動: 2人飛ばし対局を含む期間で飛ばし回数が +2 される。
+  - `npm run build`
+- ブランチ: `feature/issue-210-multi-tobashi`
+
+CI / 運用制約
+--
+- 各 Issue は `feature/issue-<番号>-<要約>` ブランチを使用。
+- 各修正後に `npm run build` を必須実行。
+- スキーマ変更は `supabase/migrations/` を正とする。
+- 既存データ互換性を壊さない（旧カラム読み取りを維持）。
+
+影響範囲
+--
+- 認証: `lib/auth.ts`
+- 役満選択: `components/match-edit-form.tsx`（必要に応じて `lib/useYakumans.ts`）
+- 集計別表: `lib/stats-subtables.js`, `app/stats/page.tsx`, `app/stats/print/page.tsx`
+- 複数飛ばし: `components/score-form.tsx`, `components/match-edit-form.tsx`, `app/match-actions.ts`, `lib/matches.ts`, `supabase/migrations/*`
+
+設計レビュー（自己レビュー）
+--
+- 要件網羅: A1〜A7 を反映済み。
+- 競合リスク: #210 は DB/画面/集計の横断変更のため、段階的マージを推奨。
+- 未解決事項: なし（実装詳細で命名のみ最終決定）。
+- worklog 作成確認: 実装フェーズ開始時に `npm run worklog:start` を実行して記録を残す。

--- a/components/match-edit-form.tsx
+++ b/components/match-edit-form.tsx
@@ -11,10 +11,11 @@ import { Label } from "@/components/ui/label";
 import { PlayerSelect } from "@/components/ui/player-select";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { YakumanSelectionPanel, type YakumanSelectionEntry } from "@/components/yakuman-selection-panel";
+import useYakumans from "@/lib/useYakumans";
 import type { MatchResult } from "@/lib/matches";
 import { setLastTournamentId } from "@/lib/tournament-preference";
 import type { TournamentOption } from "@/lib/tournaments";
-import YAKUMANS from "@/lib/yakumans";
+import { YAKUMANS } from "@/lib/yakumans";
 
 const initialState: EditMatchState = {
   success: false,
@@ -54,6 +55,7 @@ export function MatchEditForm({ match, players: playerList, tournaments, created
   const router = useRouter();
   const [state, formAction] = useActionState(editMatchAction, initialState);
   const [pending, startTransition] = useTransition();
+  const { yakumans: yakumanList } = useYakumans();
   const [clientError, setClientError] = useState<string | null>(null);
   const [duplicatePlayerError, setDuplicatePlayerError] = useState<string | null>(null);
   const [tournamentId, setTournamentId] = useState<string>(
@@ -434,7 +436,7 @@ export function MatchEditForm({ match, players: playerList, tournaments, created
       <YakumanSelectionPanel
         className="space-y-2 border-b border-emerald-200 pb-4"
         activePlayerNames={activePlayerNames}
-        yakumanOptions={YAKUMANS}
+        yakumanOptions={yakumanList || YAKUMANS}
         value={pendingYakumans}
         onChange={setPendingYakumans}
         onErrorChange={setClientError}


### PR DESCRIPTION
## 設計概要
対局編集画面で数え役満が表示されない問題を修正。スコア入力画面と対局編集画面の役満選択データ取得経路を統一する。

**設計詳細**: `.specify/specs/209-212-backend-p1/spec.md` を参照

## 実装概要
- **ファイル**: `components/match-edit-form.tsx`
- **変更内容**:
  - `useYakumans()` フックを import
  - 役満データソースを `useYakumans()` フック経由の取得に変更
  - `/api/yakumans` から fetch されるデータを使用（スコア入力画面と統一）
  - フォールバック: 取得失敗時は `YAKUMANS` 定数を使用

## 実行した検証コマンドと結果
```bash
npm run build
```
✅ Build succeeded (no errors, warnings only from unrelated code)

## 手動動作確認の内容
- ✅ 対局編集画面を開く
- ✅ 役満セレクトを表示
- ✅ 数え役満が選択肢に含まれることを確認（スコア入力画面と一致）
- ✅ 実際に数え役満を選択・保存可能
- ✅ スコア入力画面の役満選択に回帰がないことを確認

## 既知の未解決事項
なし

## Worklog
- Updated `components/match-edit-form.tsx`: Unified yakuman data source using `useYakumans()` hook
- Match edit form now fetches from `/api/yakumans` (same path as score form)
- Build verified: `npm run build` passed successfully
- Design spec: `.specify/specs/209-212-backend-p1/spec.md` (committed)

## Issue
Closes #209