### PR TITLE
fix: apply minGames filter to largestSpreads in stats subtables (#212)

### DIFF
--- a/lib/stats-subtables.js
+++ b/lib/stats-subtables.js
@@ -107,7 +107,14 @@ export function computeSubtablesFromMatches(matches = [], topN = 20, options = {
     .slice()
     .sort((a, b) => (b.score - a.score) || byCreatedDesc(a, b) || byPlayerNameAsc(a, b));
 
-  const largestSpreads = spreadEntries
+  // largestSpreads: filter by eligiblePlayers to ensure both top and last players meet criteria
+  let largeSpreadCandidates = spreadEntries;
+  if (eligiblePlayers) {
+    largeSpreadCandidates = spreadEntries.filter(
+      (entry) => eligiblePlayers.has(entry.topPlayerName) && eligiblePlayers.has(entry.lastPlayerName)
+    );
+  }
+  const largestSpreads = largeSpreadCandidates
     .slice()
     .sort((a, b) => (b.spread - a.spread) || byCreatedDesc(a, b))
     .slice(0, topN);


### PR DESCRIPTION
## 設計概要
統計表示の別表（最大点差一覧）に minGames フィルタが適用されていない問題を修正する。設定した試合数フィルタが全ての別表に一貫して適用されるようにする。

**設計詳細**: `.specify/specs/209-212-backend-p1/spec.md` を参照

## 実装概要
- **ファイル**: `lib/stats-subtables.js`
- **変更内容**:
  - `computeSubtablesFromMatches()` で `largestSpreads` を生成する際、`eligiblePlayers` フィルタを適用
  - 点差表に含まれる対局の両プレイヤーが、指定された試合数条件を満たすことを確保
  - 既存の `maxCandidates` / `minCandidates` と同じフィルタ仕様を統一

## 実行した検証コマンドと結果
```bash
npm run build
```
✅ Build succeeded (no errors, warnings only from unrelated code)

## 手動動作確認の内容
- ✅ `/stats` 画面で minGames フィルタを適用
- ✅ 上段別表（最大点差）に表示される対局に対し、プレイヤーが最小試合数条件を満たすことを確認
- ✅ 19 試合のプレイヤーがminGames=20で除外されることを確認
- ✅ 20/21試合のプレイヤーが表示されることを確認
- ✅ `/stats/print` でも同様に機能することを確認
- ✅ フィルタなし時の動作に回帰がないことを確認

## 既知の未解決事項
なし

## Worklog
- Updated `lib/stats-subtables.js`: Applied `eligiblePlayers` filter to `largestSpreads` generation
- Ensures minGames constraint is consistently applied across all subtables
- Build verified: `npm run build` passed successfully

## Issue
Closes #212