### PR TITLE
feat: 複数の飛ばしプレイヤー対応（tobashi_player_ids）#210

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -33,12 +33,13 @@ export async function saveScoreAction(
     scores: resolvedScores,
     tobiPlayers,
     tobashiPlayer,
+    tobashiPlayers,
     yakitoriPlayers,
     notes,
     total,
   } = validated.data;
 
-  const entries = buildRankedEntries(players, resolvedScores, yakitoriPlayers, tobiPlayers, tobashiPlayer);
+  const entries = buildRankedEntries(players, resolvedScores, yakitoriPlayers, tobiPlayers, tobashiPlayer, tobashiPlayers);
   const rankedEntries = [...entries].sort((left, right) => left.rank - right.rank);
   const topPlayer = rankedEntries[0]?.player ?? "";
   const lastPlayer = rankedEntries[rankedEntries.length - 1]?.player ?? "";
@@ -68,6 +69,7 @@ export async function saveScoreAction(
       ...players,
       ...tobiPlayers,
       ...(tobashiPlayer ? [tobashiPlayer] : []),
+      ...tobashiPlayers,
       ...[...yakitoriPlayers],
     ]));
     const { data: playerRows, error: playerResolveErr } = await supabase
@@ -99,6 +101,9 @@ export async function saveScoreAction(
       tobi_player_id: tobiPlayers.length === 1 ? (nameToId.get(tobiPlayers[0]) ?? null) : null,
       tobashi_player: tobashiPlayer ?? null,
       tobashi_player_id: tobashiPlayer ? (nameToId.get(tobashiPlayer) ?? null) : null,
+      tobashi_player_ids: JSON.stringify(
+        tobashiPlayers.map((n) => nameToId.get(n)).filter((id): id is number => id !== undefined)
+      ),
       yakitori_players: [...yakitoriPlayers].join(","),
       yakitori_player_ids: JSON.stringify(
         [...yakitoriPlayers].map((n) => nameToId.get(n)).filter((id): id is number => id !== undefined)

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -85,7 +85,7 @@ export async function saveScoreAction(
       nameToId.set(r.name, r.id);
     }
 
-    type RowValue = string | number | boolean | null;
+    type RowValue = string | number | boolean | null | number[];
 
     const row: Record<string, RowValue> = {
       tournament_id: tournamentId,
@@ -101,13 +101,9 @@ export async function saveScoreAction(
       tobi_player_id: tobiPlayers.length === 1 ? (nameToId.get(tobiPlayers[0]) ?? null) : null,
       tobashi_player: tobashiPlayer ?? null,
       tobashi_player_id: tobashiPlayer ? (nameToId.get(tobashiPlayer) ?? null) : null,
-      tobashi_player_ids: JSON.stringify(
-        tobashiPlayers.map((n) => nameToId.get(n)).filter((id): id is number => id !== undefined)
-      ),
+      tobashi_player_ids: tobashiPlayers.map((n) => nameToId.get(n)).filter((id): id is number => id !== undefined),
       yakitori_players: [...yakitoriPlayers].join(","),
-      yakitori_player_ids: JSON.stringify(
-        [...yakitoriPlayers].map((n) => nameToId.get(n)).filter((id): id is number => id !== undefined)
-      ),
+      yakitori_player_ids: [...yakitoriPlayers].map((n) => nameToId.get(n)).filter((id): id is number => id !== undefined),
       notes,
       created_by_user_id: session.uid,
       updated_by_user_id: session.uid,

--- a/app/match-actions.ts
+++ b/app/match-actions.ts
@@ -116,12 +116,13 @@ export async function editMatchAction(
     scores: resolvedScores,
     tobiPlayers,
     tobashiPlayer,
+    tobashiPlayers,
     yakitoriPlayers,
     notes,
     total,
   } = validated.data;
 
-  const entries = buildRankedEntries(players, resolvedScores, yakitoriPlayers, tobiPlayers, tobashiPlayer);
+  const entries = buildRankedEntries(players, resolvedScores, yakitoriPlayers, tobiPlayers, tobashiPlayer, tobashiPlayers);
   const rankedEntries = [...entries].sort((left, right) => left.rank - right.rank);
   const topPlayer = rankedEntries[0]?.player ?? "";
   const lastPlayer = rankedEntries[rankedEntries.length - 1]?.player ?? "";
@@ -152,6 +153,7 @@ export async function editMatchAction(
       ...players,
       ...tobiPlayers,
       ...(tobashiPlayer ? [tobashiPlayer] : []),
+      ...tobashiPlayers,
       ...[...yakitoriPlayers],
     ]));
     const { data: playerRows, error: playerResolveErr } = await supabase
@@ -183,6 +185,9 @@ export async function editMatchAction(
       tobi_player_id: tobiPlayers.length === 1 ? (nameToId.get(tobiPlayers[0]) ?? null) : null,
       tobashi_player: tobashiPlayer ?? null,
       tobashi_player_id: tobashiPlayer ? (nameToId.get(tobashiPlayer) ?? null) : null,
+      tobashi_player_ids: JSON.stringify(
+        tobashiPlayers.map((n) => nameToId.get(n)).filter((id): id is number => id !== undefined)
+      ),
       yakitori_players: [...yakitoriPlayers].join(","),
       yakitori_player_ids: JSON.stringify(
         [...yakitoriPlayers].map((n) => nameToId.get(n)).filter((id): id is number => id !== undefined)

--- a/app/match-actions.ts
+++ b/app/match-actions.ts
@@ -169,7 +169,7 @@ export async function editMatchAction(
       nameToId.set(r.name, r.id);
     }
 
-    type RowValue = string | number | boolean | null;
+    type RowValue = string | number | boolean | null | number[];
 
     const updatePayload: Record<string, RowValue> = {
       tournament_id: tournamentId,
@@ -185,13 +185,9 @@ export async function editMatchAction(
       tobi_player_id: tobiPlayers.length === 1 ? (nameToId.get(tobiPlayers[0]) ?? null) : null,
       tobashi_player: tobashiPlayer ?? null,
       tobashi_player_id: tobashiPlayer ? (nameToId.get(tobashiPlayer) ?? null) : null,
-      tobashi_player_ids: JSON.stringify(
-        tobashiPlayers.map((n) => nameToId.get(n)).filter((id): id is number => id !== undefined)
-      ),
+      tobashi_player_ids: tobashiPlayers.map((n) => nameToId.get(n)).filter((id): id is number => id !== undefined),
       yakitori_players: [...yakitoriPlayers].join(","),
-      yakitori_player_ids: JSON.stringify(
-        [...yakitoriPlayers].map((n) => nameToId.get(n)).filter((id): id is number => id !== undefined)
-      ),
+      yakitori_player_ids: [...yakitoriPlayers].map((n) => nameToId.get(n)).filter((id): id is number => id !== undefined),
       notes,
       updated_by_user_id: session.uid,
       updated_at: new Date().toISOString(),

--- a/components/match-edit-form.tsx
+++ b/components/match-edit-form.tsx
@@ -231,8 +231,11 @@ export function MatchEditForm({ match, players: playerList, tournaments, created
     const activePlayerSet = new Set(activePlayerNames);
     setTobiPlayers((current) => current.filter((name) => activePlayerSet.has(name)));
     setTobashiPlayers((current) => current.filter((name) => activePlayerSet.has(name)));
+  }, [activePlayerNames]);
+
+  useEffect(() => {
     setTobashiPlayers((current) => current.filter((name) => !tobiPlayers.includes(name)));
-  }, [activePlayerNames, tobiPlayers]);
+  }, [tobiPlayers]);
 
   useEffect(() => {
     if (gameType === "3p") {

--- a/components/match-edit-form.tsx
+++ b/components/match-edit-form.tsx
@@ -22,7 +22,6 @@ const initialState: EditMatchState = {
   message: "",
 };
 
-const NONE_VALUE = "__none__";
 
 type GameType = "3p" | "4p";
 
@@ -84,7 +83,9 @@ export function MatchEditForm({ match, players: playerList, tournaments, created
           .filter(Boolean)
       : []
   );
-  const [tobashiPlayer, setTobashiPlayer] = useState(match.tobashiPlayer || NONE_VALUE);
+  const [tobashiPlayers, setTobashiPlayers] = useState<string[]>(
+    match.players.filter((p) => p.isTobashi).map((p) => p.name)
+  );
   const [yakitoriFlags, setYakitoriFlags] = useState<Record<number, boolean>>({
     1: match.players[0]?.isYakitori ?? false,
     2: match.players[1]?.isYakitori ?? false,
@@ -229,15 +230,9 @@ export function MatchEditForm({ match, players: playerList, tournaments, created
   useEffect(() => {
     const activePlayerSet = new Set(activePlayerNames);
     setTobiPlayers((current) => current.filter((name) => activePlayerSet.has(name)));
-
-    if (tobashiPlayer !== NONE_VALUE && !activePlayerSet.has(tobashiPlayer)) {
-      setTobashiPlayer(NONE_VALUE);
-    }
-
-    if (tobashiPlayer !== NONE_VALUE) {
-      setTobiPlayers((current) => current.filter((name) => name !== tobashiPlayer));
-    }
-  }, [activePlayerNames, tobashiPlayer]);
+    setTobashiPlayers((current) => current.filter((name) => activePlayerSet.has(name)));
+    setTobashiPlayers((current) => current.filter((name) => !tobiPlayers.includes(name)));
+  }, [activePlayerNames, tobiPlayers]);
 
   useEffect(() => {
     if (gameType === "3p") {
@@ -265,7 +260,8 @@ export function MatchEditForm({ match, players: playerList, tournaments, created
       form.append(`yakitori${slot}`, yakitoriFlags[slot] ? "on" : "off");
     });
     form.append("tobiPlayers", tobiPlayers.join(","));
-    form.append("tobashiPlayer", tobashiPlayer === NONE_VALUE ? "" : tobashiPlayer);
+    form.append("tobashiPlayers", JSON.stringify(tobashiPlayers));
+    form.append("tobashiPlayer", tobashiPlayers[0] ?? "");
     form.append("notes", notes);
 
     const activePlayerSet = new Set(
@@ -357,7 +353,7 @@ export function MatchEditForm({ match, players: playerList, tournaments, created
                   onValueChange={(value) => {
                     setPlayers((prev) => ({ ...prev, [slot]: value }));
                     setTobiPlayers((current) => current.filter((name) => name !== value));
-                    if (value === tobashiPlayer) setTobashiPlayer(NONE_VALUE);
+                    setTobashiPlayers((current) => current.filter((name) => name !== value));
                   }}
                   options={playerList}
                   exclude={activeSlots
@@ -451,7 +447,7 @@ export function MatchEditForm({ match, players: playerList, tournaments, created
           <div id="tobiPlayer" className="space-y-2 rounded-md border border-border/70 bg-white/70 p-3">
             {playersToCheck.map((player) => {
               const checked = tobiPlayers.includes(player);
-              const disabled = player === tobashiPlayer;
+              const disabled = tobashiPlayers.includes(player);
               return (
                 <label key={`tobi-${player}`} className="flex items-center gap-2 text-sm">
                   <input
@@ -473,30 +469,32 @@ export function MatchEditForm({ match, players: playerList, tournaments, created
               );
             })}
           </div>
-          <Select
-            value={tobashiPlayer}
-            onValueChange={(value) => {
-              setTobashiPlayer(value);
-              if (value !== NONE_VALUE) {
-                setTobiPlayers((current) => current.filter((name) => name !== value));
-              }
-            }}
-          >
-            <SelectTrigger>
-              <SelectValue placeholder="飛ばし者" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value={NONE_VALUE}>なし</SelectItem>
-              {playersToCheck.map((player) => {
-                const isDisabled = tobiPlayers.includes(player) && player !== tobashiPlayer;
-                return (
-                  <SelectItem key={`tobashi-${player}`} value={player} disabled={isDisabled}>
-                    {player} が飛ばし
-                  </SelectItem>
-                );
-              })}
-            </SelectContent>
-          </Select>
+          <div className="space-y-2 rounded-md border border-border/70 bg-white/70 p-3">
+            {playersToCheck.map((player) => {
+              const checked = tobashiPlayers.includes(player);
+              const disabled = tobiPlayers.includes(player);
+              return (
+                <label key={`tobashi-${player}`} className="flex items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    className="h-4 w-4 rounded border border-input"
+                    checked={checked}
+                    disabled={disabled}
+                    onChange={(event) => {
+                      setTobashiPlayers((current) => {
+                        const next = event.target.checked
+                          ? current.includes(player) ? current : [...current, player]
+                          : current.filter((name) => name !== player);
+                        setTobiPlayers((tobiCurrent) => tobiCurrent.filter((name) => !next.includes(name)));
+                        return next;
+                      });
+                    }}
+                  />
+                  <span>{player} が飛ばし</span>
+                </label>
+              );
+            })}
+          </div>
         </div>
       </div>
 

--- a/components/score-form.tsx
+++ b/components/score-form.tsx
@@ -174,14 +174,13 @@ export function ScoreForm({ players: playerList, tournaments }: ScoreFormProps) 
 
   useEffect(() => {
     const playerNames = new Set(activePlayers.map((entry) => entry.name));
-
     setTobiPlayers((current) => current.filter((player) => playerNames.has(player)));
+    setTobashiPlayers((current) => current.filter((p) => playerNames.has(p)));
+  }, [activePlayers]);
 
-    if (tobashiPlayers.length > 0 && !playerNames.has(tobashiPlayers[0])) {
-      setTobashiPlayers((current) => current.filter((p) => playerNames.has(p)));
-    }
+  useEffect(() => {
     setTobashiPlayers((current) => current.filter((p) => !tobiPlayers.includes(p)));
-  }, [activePlayers, tobashiPlayers, tobiPlayers]);
+  }, [tobiPlayers]);
 
   useEffect(() => {
     const selectedPlayers = activeSlots

--- a/components/score-form.tsx
+++ b/components/score-form.tsx
@@ -21,7 +21,6 @@ const initialState: SaveScoreState = {
   message: "",
 };
 
-const NONE_VALUE = "__none__";
 
 type GameType = "3p" | "4p";
 
@@ -57,7 +56,7 @@ export function ScoreForm({ players: playerList, tournaments }: ScoreFormProps) 
   const [scores, setScores] = useState<Record<number, string>>({});
   const [autoFilledSlot, setAutoFilledSlot] = useState<number | null>(null);
   const [tobiPlayers, setTobiPlayers] = useState<string[]>([]);
-  const [tobashiPlayer, setTobashiPlayer] = useState(NONE_VALUE);
+  const [tobashiPlayers, setTobashiPlayers] = useState<string[]>([]);
   const [yakitoriSlots, setYakitoriSlots] = useState<Record<number, boolean>>({});
   const [notes, setNotes] = useState("");
   const [pendingYakumans, setPendingYakumans] = useState<YakumanSelectionEntry[]>([]);
@@ -88,7 +87,7 @@ export function ScoreForm({ players: playerList, tournaments }: ScoreFormProps) 
     setScores({});
     setAutoFilledSlot(null);
     setTobiPlayers([]);
-    setTobashiPlayer(NONE_VALUE);
+    setTobashiPlayers([]);
     setYakitoriSlots({});
     setNotes("");
     setPendingYakumans([]);
@@ -178,14 +177,11 @@ export function ScoreForm({ players: playerList, tournaments }: ScoreFormProps) 
 
     setTobiPlayers((current) => current.filter((player) => playerNames.has(player)));
 
-    if (tobashiPlayer !== NONE_VALUE && !playerNames.has(tobashiPlayer)) {
-      setTobashiPlayer(NONE_VALUE);
+    if (tobashiPlayers.length > 0 && !playerNames.has(tobashiPlayers[0])) {
+      setTobashiPlayers((current) => current.filter((p) => playerNames.has(p)));
     }
-
-    if (tobashiPlayer !== NONE_VALUE) {
-      setTobiPlayers((current) => current.filter((player) => player !== tobashiPlayer));
-    }
-  }, [activePlayers, tobashiPlayer]);
+    setTobashiPlayers((current) => current.filter((p) => !tobiPlayers.includes(p)));
+  }, [activePlayers, tobashiPlayers, tobiPlayers]);
 
   useEffect(() => {
     const selectedPlayers = activeSlots
@@ -321,13 +317,13 @@ export function ScoreForm({ players: playerList, tournaments }: ScoreFormProps) 
               return;
             }
 
-            if ((tobiPlayers.length === 0 && tobashiPlayer !== NONE_VALUE) || (tobiPlayers.length > 0 && tobashiPlayer === NONE_VALUE)) {
+            if ((tobiPlayers.length === 0 && tobashiPlayers.length > 0) || (tobiPlayers.length > 0 && tobashiPlayers.length === 0)) {
               e.preventDefault();
               setClientError("飛び対象と飛ばし者は両方セットで選択してください。");
               return;
             }
 
-            if (tobashiPlayer !== NONE_VALUE && tobiPlayers.includes(tobashiPlayer)) {
+            if (tobashiPlayers.some((p) => tobiPlayers.includes(p))) {
               e.preventDefault();
               setClientError("飛び対象と飛ばし者に同じプレイヤーは選べません。");
               return;
@@ -481,7 +477,7 @@ export function ScoreForm({ players: playerList, tournaments }: ScoreFormProps) 
               <div className="space-y-2 rounded-md border border-border/70 bg-white/70 p-3">
                 {activePlayers.map((player) => {
                   const checked = tobiPlayers.includes(player.name);
-                  const disabled = player.name === tobashiPlayer;
+                  const disabled = tobashiPlayers.includes(player.name);
                   return (
                     <label key={`tobi-${player.name}`} className="flex items-center gap-2 text-sm">
                       <input
@@ -508,31 +504,34 @@ export function ScoreForm({ players: playerList, tournaments }: ScoreFormProps) 
 
             <div className="space-y-2">
               <Label>飛ばし者</Label>
-                <Select
-                  name="tobashiPlayer"
-                  value={tobashiPlayer}
-                  onValueChange={(value) => {
-                    setTobashiPlayer(value);
-                    if (value !== NONE_VALUE) {
-                      setTobiPlayers((current) => current.filter((name) => name !== value));
-                    }
-                  }}
-                >
-                <SelectTrigger>
-                  <SelectValue placeholder="なし" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value={NONE_VALUE}>なし</SelectItem>
-                    {activePlayers.map((player) => {
-                      const isDisabled = tobiPlayers.includes(player.name) && player.name !== tobashiPlayer;
-                      return (
-                        <SelectItem key={`tobashi-${player.name}`} value={player.name} disabled={isDisabled}>
-                          {player.name}
-                        </SelectItem>
-                      );
-                    })}
-                </SelectContent>
-              </Select>
+              <div className="space-y-2 rounded-md border border-border/70 bg-white/70 p-3">
+                {activePlayers.map((player) => {
+                  const checked = tobashiPlayers.includes(player.name);
+                  const disabled = tobiPlayers.includes(player.name);
+                  return (
+                    <label key={`tobashi-${player.name}`} className="flex items-center gap-2 text-sm">
+                      <input
+                        type="checkbox"
+                        className="h-4 w-4 rounded border border-input"
+                        checked={checked}
+                        disabled={disabled}
+                        onChange={(event) => {
+                          setTobashiPlayers((current) => {
+                            const next = event.target.checked
+                              ? current.includes(player.name) ? current : [...current, player.name]
+                              : current.filter((name) => name !== player.name);
+                            setTobiPlayers((tobiCurrent) => tobiCurrent.filter((name) => !next.includes(name)));
+                            return next;
+                          });
+                        }}
+                      />
+                      <span>{player.name}</span>
+                    </label>
+                  );
+                })}
+              </div>
+              <input type="hidden" name="tobashiPlayers" value={JSON.stringify(tobashiPlayers)} />
+              <input type="hidden" name="tobashiPlayer" value={tobashiPlayers[0] ?? ""} />
             </div>
 
             <div className="md:col-span-2">

--- a/lib/matches.ts
+++ b/lib/matches.ts
@@ -34,6 +34,7 @@ export type MatchResult = {
   tobiPlayerId: number | null;
   tobashiPlayer: string | null;
   tobashiPlayerId: number | null;
+  tobashiPlayerIds: number[];
   yakitoriPlayers: string[];
   yakitoriPlayerIds: number[];
   notes: string;
@@ -90,7 +91,7 @@ export async function fetchMatchResults(startDate?: string, endDate?: string, op
   const supabase = createClient(supabaseUrl, supabaseKey, { auth: { persistSession: false } });
 
   try {
-    const selection = `id,tournament_id,tournaments(name),date,game_type,player_count,player1,player2,player3,player4,player1_id,player2_id,player3_id,player4_id,score1,score2,score3,score4,rank1,rank2,rank3,rank4,is_tobi1,is_tobi2,is_tobi3,is_tobi4,is_tobashi1,is_tobashi2,is_tobashi3,is_tobashi4,is_yakitori1,is_yakitori2,is_yakitori3,is_yakitori4,score_total,top_player,top_player_id,last_player,last_player_id,tobi_player,tobi_player_id,tobashi_player,tobashi_player_id,yakitori_players,yakitori_player_ids,notes,created_at`;
+    const selection = `id,tournament_id,tournaments(name),date,game_type,player_count,player1,player2,player3,player4,player1_id,player2_id,player3_id,player4_id,score1,score2,score3,score4,rank1,rank2,rank3,rank4,is_tobi1,is_tobi2,is_tobi3,is_tobi4,is_tobashi1,is_tobashi2,is_tobashi3,is_tobashi4,is_yakitori1,is_yakitori2,is_yakitori3,is_yakitori4,score_total,top_player,top_player_id,last_player,last_player_id,tobi_player,tobi_player_id,tobashi_player,tobashi_player_id,tobashi_player_ids,yakitori_players,yakitori_player_ids,notes,created_at`;
 
     let qb = supabase.from("games").select(selection);
     if (typeof options.tournamentId === "number") qb = qb.eq("tournament_id", options.tournamentId);
@@ -139,6 +140,10 @@ export async function fetchMatchResults(startDate?: string, endDate?: string, op
       const yakitoriPlayerIds: number[] = Array.isArray(rawYakitoriIds)
         ? (rawYakitoriIds as unknown[]).map(Number).filter((n) => Number.isFinite(n))
         : [];
+      const rawTobashiIds = row["tobashi_player_ids"];
+      const tobashiPlayerIds: number[] = Array.isArray(rawTobashiIds)
+        ? (rawTobashiIds as unknown[]).map(Number).filter((n) => Number.isFinite(n))
+        : [];
       const rawTournament = row["tournaments"] as { name?: unknown } | Array<{ name?: unknown }> | null | undefined;
       const tournamentRelation = Array.isArray(rawTournament) ? rawTournament[0] : rawTournament;
 
@@ -158,6 +163,7 @@ export async function fetchMatchResults(startDate?: string, endDate?: string, op
         tobiPlayerId: toNullableId(row["tobi_player_id"]),
         tobashiPlayer: row["tobashi_player"] ? String(row["tobashi_player"]) : null,
         tobashiPlayerId: toNullableId(row["tobashi_player_id"]),
+        tobashiPlayerIds,
         yakitoriPlayers: String(row["yakitori_players"] ?? "")
           .split(",")
           .map((s) => s.trim())

--- a/lib/stats.ts
+++ b/lib/stats.ts
@@ -73,12 +73,20 @@ function buildPlayerAccumulators(matches: MatchResult[]): Map<string, PlayerAccu
     }
 
     // tobashiCount: use tobashiPlayerIds for multi-tobashi support
+    // Fall back to legacy tobashiPlayerId for records created before the multi-tobashi migration
     if (match.tobashiPlayerIds && match.tobashiPlayerIds.length > 0) {
       const tobashiNames = match.players
         .filter((p) => p.id !== null && match.tobashiPlayerIds!.includes(p.id))
         .map((p) => p.name.trim());
       for (const name of tobashiNames) {
         const acc = playerMap.get(name);
+        if (acc) acc.tobashiCount += 1;
+      }
+    } else if (match.tobashiPlayerId !== null && match.tobashiPlayerId !== undefined) {
+      // Legacy fallback: single tobashiPlayerId (pre-multi-tobashi data)
+      const tobashiPlayer = match.players.find((p) => p.id === match.tobashiPlayerId);
+      if (tobashiPlayer) {
+        const acc = playerMap.get(tobashiPlayer.name.trim());
         if (acc) acc.tobashiCount += 1;
       }
     }

--- a/lib/stats.ts
+++ b/lib/stats.ts
@@ -67,10 +67,20 @@ function buildPlayerAccumulators(matches: MatchResult[]): Map<string, PlayerAccu
       if (p.rank === playerCount) acc.lastCount += 1;
       if (p.rank === 2) acc.secondCount += 1;
       if (p.rank === 3) acc.thirdCount += 1;
-      if (p.isTobashi) acc.tobashiCount += 1;
       if (p.isTobi) acc.tobiCount += 1;
       if (p.isYakitori) acc.yakitoriCount += 1;
       acc.yakumanCount += p.yakumans?.length ?? 0;
+    }
+
+    // tobashiCount: use tobashiPlayerIds for multi-tobashi support
+    if (match.tobashiPlayerIds && match.tobashiPlayerIds.length > 0) {
+      const tobashiNames = match.players
+        .filter((p) => p.id !== null && match.tobashiPlayerIds!.includes(p.id))
+        .map((p) => p.name.trim());
+      for (const name of tobashiNames) {
+        const acc = playerMap.get(name);
+        if (acc) acc.tobashiCount += 1;
+      }
     }
   }
 

--- a/lib/validate-match.ts
+++ b/lib/validate-match.ts
@@ -49,6 +49,7 @@ export type ParsedMatchData = {
   scores: number[];
   tobiPlayers: string[];
   tobashiPlayer: string | null;
+  tobashiPlayers: string[];
   yakitoriPlayers: Set<string>;
   notes: string;
   total: number;
@@ -116,6 +117,18 @@ export function validateAndParseMatchForm(formData: FormData): { ok: true; data:
       return single ? [single] : [];
     })();
   const tobashiPlayer = parseOptionalPlayer(formData.get("tobashiPlayer"));
+  // tobashiPlayers: JSON array from multi-select checkboxes (new), falls back to single tobashiPlayer
+  const tobashiPlayersRaw = parseString(formData.get("tobashiPlayers"));
+  const tobashiPlayers: string[] = tobashiPlayersRaw
+    ? (() => {
+        try {
+          const parsed = JSON.parse(tobashiPlayersRaw);
+          return Array.isArray(parsed) ? parsed.filter((n): n is string => typeof n === "string" && n !== NONE_VALUE) : [];
+        } catch {
+          return [];
+        }
+      })()
+    : tobashiPlayer ? [tobashiPlayer] : [];
   const yakitoriPlayers = new Set(
     activeSlots
       .filter((slot) => formData.get(`yakitori${slot}`) === "on")
@@ -123,7 +136,7 @@ export function validateAndParseMatchForm(formData: FormData): { ok: true; data:
       .filter(Boolean)
   );
 
-  if ((tobiPlayers.length > 0 && !tobashiPlayer) || (tobiPlayers.length === 0 && tobashiPlayer)) {
+  if ((tobiPlayers.length > 0 && tobashiPlayers.length === 0) || (tobiPlayers.length === 0 && tobashiPlayers.length > 0)) {
     return { ok: false, message: "飛びと飛ばしは両方セットで指定してください。" };
   }
 
@@ -131,11 +144,11 @@ export function validateAndParseMatchForm(formData: FormData): { ok: true; data:
     return { ok: false, message: "飛び対象は同卓プレイヤーから選択してください。" };
   }
 
-  if (tobashiPlayer && !players.includes(tobashiPlayer)) {
+  if (tobashiPlayers.some((p) => !players.includes(p))) {
     return { ok: false, message: "飛ばし者は同卓プレイヤーから選択してください。" };
   }
 
-  if (tobashiPlayer && tobiPlayers.includes(tobashiPlayer)) {
+  if (tobashiPlayers.some((p) => tobiPlayers.includes(p))) {
     return { ok: false, message: "飛び対象と飛ばし者に同じプレイヤーは指定できません。" };
   }
 
@@ -152,6 +165,7 @@ export function validateAndParseMatchForm(formData: FormData): { ok: true; data:
       scores: resolvedScores,
       tobiPlayers,
       tobashiPlayer,
+      tobashiPlayers,
       yakitoriPlayers,
       notes,
       total,
@@ -164,7 +178,8 @@ export function buildRankedEntries(
   scores: number[],
   yakitoriPlayers: Set<string>,
   tobiPlayers: string[],
-  tobashiPlayer: string | null
+  tobashiPlayer: string | null,
+  tobashiPlayers: string[] = []
 ) {
   const ranked = players
     .map((player, index) => ({
@@ -186,7 +201,7 @@ export function buildRankedEntries(
     score: scores[index],
     rank: rankBySlot.get(index + 1) ?? players.length,
     isTobi: tobiPlayers.includes(player),
-    isTobashi: tobashiPlayer === player,
+    isTobashi: tobashiPlayers.length > 0 ? tobashiPlayers.includes(player) : tobashiPlayer === player,
     isYakitori: yakitoriPlayers.has(player),
   })) as GameEntry[];
 }

--- a/supabase/migrations/20260504000000_add_tobashi_player_ids.sql
+++ b/supabase/migrations/20260504000000_add_tobashi_player_ids.sql
@@ -1,0 +1,7 @@
+-- Add tobashi_player_ids column to support multiple tobashi players (issue #210)
+-- Backward compatible: existing tobashi_player and tobashi_player_id columns are preserved
+
+ALTER TABLE games
+  ADD COLUMN IF NOT EXISTS tobashi_player_ids jsonb NOT NULL DEFAULT '[]'::jsonb;
+
+COMMENT ON COLUMN games.tobashi_player_ids IS 'Array of player IDs who performed tobashi (飛ばし). Replaces single tobashi_player_id for multi-player support.';

--- a/supabase/migrations/20260504000001_backfill_tobashi_player_ids.sql
+++ b/supabase/migrations/20260504000001_backfill_tobashi_player_ids.sql
@@ -1,0 +1,16 @@
+-- Backfill tobashi_player_ids from legacy tobashi_player_id column
+-- Records created before the multi-tobashi migration have tobashi_player_ids = '[]'
+-- but may have tobashi_player_id set (single tobashi player).
+-- This migration copies the single ID into the array for backward compatibility.
+
+-- Step 1: Backfill from legacy tobashi_player_id (single tobashi, pre-multi-tobashi data)
+UPDATE games
+SET tobashi_player_ids = jsonb_build_array(tobashi_player_id)
+WHERE tobashi_player_id IS NOT NULL
+  AND (tobashi_player_ids IS NULL OR tobashi_player_ids = '[]'::jsonb);
+
+-- Step 2: Fix records where tobashi_player_ids was stored as a JSON string (e.g. '"[4,5]"')
+-- instead of a proper jsonb array. This happened when JSON.stringify was called before INSERT.
+UPDATE games
+SET tobashi_player_ids = (tobashi_player_ids #>> '{}')::jsonb
+WHERE jsonb_typeof(tobashi_player_ids) = 'string';

--- a/test/score-save-to-stats.e2e.test.cjs
+++ b/test/score-save-to-stats.e2e.test.cjs
@@ -75,4 +75,47 @@ describe("score input to stats reflection (e2e-like)", () => {
     assert.strictEqual(dave.lastCount, 1, "last rank should be reflected");
     assert.strictEqual(dave.tobiCount, 1, "tobi should be reflected");
   });
+
+  it("reflects multi-tobashi (tobashiPlayers array) into ranked entries", () => {
+    const formData = buildFormData({
+      tournamentId: 1,
+      gameDate: "2026-04-27",
+      gameType: "4p",
+      player1: "Alice",
+      player2: "Bob",
+      player3: "Carol",
+      player4: "Dave",
+      score1: "350",
+      score2: "100",
+      score3: "-150",
+      score4: "-300",
+      tobiPlayers: "Carol,Dave",
+      tobashiPlayers: JSON.stringify(["Alice", "Bob"]),
+      tobashiPlayer: "Alice",
+      notes: "multi-tobashi test",
+    });
+
+    const parsed = validateAndParseMatchForm(formData);
+    assert.ok(parsed.ok, "multi-tobashi form should pass validation");
+    assert.deepStrictEqual(parsed.data.tobashiPlayers, ["Alice", "Bob"], "tobashiPlayers should contain both players");
+
+    const entries = buildRankedEntries(
+      parsed.data.players,
+      parsed.data.scores,
+      parsed.data.yakitoriPlayers,
+      parsed.data.tobiPlayers,
+      parsed.data.tobashiPlayer,
+      parsed.data.tobashiPlayers
+    );
+
+    const alice = entries.find((e) => e.player === "Alice");
+    const bob = entries.find((e) => e.player === "Bob");
+    const carol = entries.find((e) => e.player === "Carol");
+    assert.ok(alice?.isTobashi, "Alice should be tobashi");
+    assert.ok(bob?.isTobashi, "Bob should be tobashi");
+    assert.ok(!carol?.isTobashi, "Carol should not be tobashi");
+
+    const summary = summarize(entries);
+    assert.strictEqual(summary.filter((r) => r.tobashiCount === 1).length, 2, "both tobashi players should have tobashiCount=1");
+  });
 });

--- a/test/validate-match.cjs
+++ b/test/validate-match.cjs
@@ -152,6 +152,45 @@ function run() {
   assert.ok(!res.ok, 'out-of-range score should fail');
   assert.ok(/スコア/.test(res.message || ''), 'error message should mention score range constraint');
 
+  // tobashiPlayers: JSON array form (multi-tobashi)
+  fd = fdFrom({
+    gameDate: '2026-04-06',
+    gameType: '4p',
+    player1: 'A',
+    player2: 'B',
+    player3: 'C',
+    player4: 'D',
+    score1: '250',
+    score2: '100',
+    score3: '-200',
+    score4: '-150',
+    tobiPlayers: 'C,D',
+    tobashiPlayers: JSON.stringify(['A', 'B']),
+    tobashiPlayer: 'A',
+  });
+  res = validateAndParseMatchForm(fd);
+  assert.ok(res.ok, 'multi-tobashi JSON array form should parse');
+  assert.deepStrictEqual(res.data.tobashiPlayers, ['A', 'B'], 'tobashiPlayers should contain both players');
+
+  // tobashiPlayers: fallback to single tobashiPlayer when tobashiPlayers absent
+  fd = fdFrom({
+    gameDate: '2026-04-06',
+    gameType: '4p',
+    player1: 'A',
+    player2: 'B',
+    player3: 'C',
+    player4: 'D',
+    score1: '250',
+    score2: '100',
+    score3: '-200',
+    score4: '-150',
+    tobiPlayer: 'C',
+    tobashiPlayer: 'D',
+  });
+  res = validateAndParseMatchForm(fd);
+  assert.ok(res.ok, 'single tobashiPlayer fallback should parse');
+  assert.deepStrictEqual(res.data.tobashiPlayers, ['D'], 'tobashiPlayers should fall back to tobashiPlayer value');
+
   // tournament filter parser contract (used by matches/stats/print)
   const params = resolveFilterParams({
     filterRaw: 'year',


### PR DESCRIPTION
## spec

小規模修正のため PR 本文に代替 spec を記載。

- **目的**: 複数プレイヤーの飛ばし（tobashi）を1対局で記録・集計できるようにする
- **対象**: score-form, match-edit-form, validate-match, actions, matches, stats, migration
- **影響範囲**: スコア入力 UI / 対局編集 UI / 統計集計ロジック / DB スキーマ

## 設計概要

- `games` テーブルに `tobashi_player_ids jsonb NOT NULL DEFAULT '[]'::jsonb` を追加
- フォームは `tobashiPlayers`（JSON 配列）と後方互換用 `tobashiPlayer`（先頭1件）を送信
- 統計は `match.tobashiPlayerIds` 配列ベースで各プレイヤーの `tobashiCount` を加算

## 実装概要

| ファイル | 変更内容 |
|---|---|
| `supabase/migrations/20260504000000_add_tobashi_player_ids.sql` | tobashi_player_ids カラム追加 |
| `lib/validate-match.ts` | tobashiPlayers JSON 配列パース・後方互換フォールバック |
| `app/actions.ts` / `app/match-actions.ts` | tobashi_player_ids を保存 |
| `lib/matches.ts` | MatchResult に tobashiPlayerIds: number[] を追加 |
| `components/score-form.tsx` | 飛ばし UI をチェックボックス複数選択に変更、useEffect 無限ループ修正 |
| `components/match-edit-form.tsx` | 同上 |
| `lib/stats.ts` | tobashiPlayerIds 配列ベースで tobashiCount を加算（legacy fallback あり） |
| `supabase/migrations/20260504000001_backfill_tobashi_player_ids.sql` | 旧データ backfill / string誤保存データ補正 |
| `test/validate-match.cjs` | tobashiPlayers 配列パースのユニットテスト追加 |
| `test/score-save-to-stats.e2e.test.cjs` | multi-tobashi E2E テスト追加 |

## 実行した検証コマンドと結果

```
npm run build  → ✓ 成功（警告のみ）
npx playwright test --reporter=list  → 5/5 passed (15.3s)
node test/validate-match.cjs  → 全テスト pass
node test/score-save-to-stats.e2e.test.cjs  → 全テスト pass
```

## 手動動作確認の内容

- Playwright E2E テスト 5件 PASS にて代替確認済み
- 2026/5/4 の複数飛ばしレコードで `tobashi_player_ids` が2人分展開されることを DB クエリで確認済み

## 既知の未解決事項

- `games` テーブルには移行互換のため重複カラムが残存（`tobashi_player` / `tobashi_player_id` / `is_tobashi1..4` と `tobashi_player_ids`）。
- 将来のクリーンアップ用に移行 Issue を別途作成予定。

## worklog

作業ログは `.worklog/logs/2026-05-04.md` に記録済み（gitignore 対象）。