### PR TITLE
feat: #214 飛び・焼き鳥回数をランクバッジ対象指標に追加

### DIFF
--- a/lib/metric-ranks.js
+++ b/lib/metric-ranks.js
@@ -14,6 +14,9 @@ export const METRIC_DIRECTION = {
   setaiRate: "desc",
   // lastCount is better when smaller
   lastCount: "asc",
+  // tobiCount/yakitoriCount: fewer is better
+  tobiCount: "asc",
+  yakitoriCount: "asc",
 };
 
 export const METRICS_TO_HIGHLIGHT = Object.keys(METRIC_DIRECTION);


### PR DESCRIPTION
## 設計概要
Issue #214: 成績集計テーブルの「飛び」「焼き鳥」列にランクバッジ（1位・2位・3位）を表示する。

## 実装概要
- `lib/metric-ranks.js` の `METRIC_DIRECTION` に `tobiCount: "asc"`・`yakitoriCount: "asc"` を追加
- 飛ばされた回数・焼き鳥回数は少ない方が優位なため昇順評価
- `components/stats-sortable-table.tsx` の getCellHighlight 呼び出しは既存実装済みのため変更不要

## 実行した検証コマンドと結果
```
npm run build → ✅ 成功
npm test      → ✅ 4/4 pass
```

## 手動動作確認の内容
- Playwright ブラウザ（http://localhost:3001/stats）で「飛び」列と「焼き鳥」列にランクバッジが表示されることを目視確認
- 値が0の行にオレンジ（1位）バッジ、次点にゴールド（2位）バッジが表示された

## 既知の未解決事項
なし

Closes #214

## Worklog
- worklog: .worklog/logs/2026-05-06.md に記録を追記済み
- worklog: 作業単位（#213/#214/#215）でエントリを分割して記録