### PR TITLE
feat: #215 PDF出力の順位列にランクバッジを適用

### DIFF
--- a/app/stats/print/client.tsx
+++ b/app/stats/print/client.tsx
@@ -9,14 +9,18 @@ import type { PlayerStats } from "@/lib/stats";
 import type { ScoreRank, SpreadRank, YakumanEvent } from "@/lib/stats-subtables";
 import "./print.css";
 
+type RankSets = { first: string[]; second: string[]; third: string[] };
+
 type Props = {
   stats: PlayerStats[];
+  topSets: Record<string, RankSets>;
   yakumanEvents: YakumanEvent[];
   highestScores: ScoreRank[];
   lowestScores: ScoreRank[];
   largestSpreads: SpreadRank[];
   matches: MatchResult[];
   statsYearly: PlayerStats[];
+  topSetsYearly: Record<string, RankSets>;
   yakumanEventsYearly: YakumanEvent[];
   highestScoresYearly: ScoreRank[];
   lowestScoresYearly: ScoreRank[];
@@ -29,12 +33,14 @@ type Props = {
 
 export default function ClientStatsPrintPage({
   stats,
+  topSets,
   yakumanEvents,
   highestScores,
   lowestScores,
   largestSpreads,
   matches,
   statsYearly,
+  topSetsYearly,
   yakumanEventsYearly,
   highestScoresYearly,
   lowestScoresYearly,
@@ -88,7 +94,7 @@ export default function ClientStatsPrintPage({
           </div>
 
           <div className="p-4">
-            <StatsSummaryTable stats={stats ?? []} title="成績集計" />
+            <StatsSummaryTable stats={stats ?? []} topSets={topSets ?? {}} title="成績集計" />
 
             <ExtraStatsTable
               yakumanEvents={yakumanEvents ?? []}
@@ -102,7 +108,7 @@ export default function ClientStatsPrintPage({
             <MatchHistoryTable matches={matches ?? []} />
 
             <div className="break-after-page page-break-after-always" />
-            <StatsSummaryTable stats={statsYearly ?? []} title="成績集計（今年・20試合以上）" />
+            <StatsSummaryTable stats={statsYearly ?? []} topSets={topSetsYearly ?? {}} title="成績集計（今年・20試合以上）" />
 
             <ExtraStatsTable
               yakumanEvents={yakumanEventsYearly ?? []}

--- a/app/stats/print/page.tsx
+++ b/app/stats/print/page.tsx
@@ -1,5 +1,6 @@
 import { resolveFilterParams } from "@/lib/filter-params";
 import { fetchMatchResults } from "@/lib/matches";
+import { computeTopSets, METRIC_DIRECTION, METRICS_TO_HIGHLIGHT } from "@/lib/metric-ranks";
 import { fetchPlayerStats } from "@/lib/stats";
 import { fetchStatsSubtables } from "@/lib/stats-subtables";
 import { fetchTournamentById } from "@/lib/tournaments";
@@ -66,6 +67,9 @@ export default async function StatsPrintPage({ searchParams }: { searchParams?: 
     largestSpreads: largestSpreadsYearly,
   } = await fetchStatsSubtables(yearStart, yearEnd, 5, { minGames: 20, tournamentId });
 
+  const topSets = computeTopSets(stats, METRICS_TO_HIGHLIGHT, METRIC_DIRECTION);
+  const topSetsYearly = computeTopSets(statsYearly, METRICS_TO_HIGHLIGHT, METRIC_DIRECTION);
+
   const tournament = typeof tournamentId === "number" ? await fetchTournamentById(tournamentId) : null;
 
   // ヘッダー用文言生成
@@ -87,6 +91,7 @@ export default async function StatsPrintPage({ searchParams }: { searchParams?: 
   return (
     <ClientStatsPrintPage
       stats={stats}
+      topSets={topSets}
       yakumanEvents={yakumanEvents}
       highestScores={highestScores}
       lowestScores={lowestScores}
@@ -94,6 +99,7 @@ export default async function StatsPrintPage({ searchParams }: { searchParams?: 
       matches={matches}
       // yearly reference
       statsYearly={statsYearly}
+      topSetsYearly={topSetsYearly}
       yakumanEventsYearly={yakumanEventsYearly}
       highestScoresYearly={highestScoresYearly}
       lowestScoresYearly={lowestScoresYearly}

--- a/components/stats-print/StatsSummaryTable.tsx
+++ b/components/stats-print/StatsSummaryTable.tsx
@@ -1,4 +1,5 @@
 import type { PlayerStats } from "@/lib/stats";
+import { RANK_BADGE } from "@/lib/stats-rank-theme";
 import React from "react";
 
 interface StatsSummaryTableProps {
@@ -44,7 +45,15 @@ export const StatsSummaryTable: React.FC<StatsSummaryTableProps> = ({ stats, tit
         <tbody>
           {stats.map((p) => (
             <tr key={p.name} className="border-t h-8">
-              <td className="px-2 py-0 text-center align-middle leading-4">{p.rank}</td>
+              <td className="px-2 py-0 text-center align-middle leading-4">
+                {RANK_BADGE[p.rank] ? (
+                  <span className={`inline-flex h-5 min-w-[1.25rem] items-center justify-center rounded px-1 text-[10px] font-bold ${RANK_BADGE[p.rank]}`}>
+                    {p.rank}
+                  </span>
+                ) : (
+                  p.rank
+                )}
+              </td>
               <td className="px-2 py-0 align-middle leading-4 whitespace-nowrap">{p.name}</td>
               <td className="px-2 py-0 text-right tabular-nums align-middle leading-4">{p.games}</td>
               <td className={`px-2 py-0 text-right tabular-nums align-middle leading-4 ${p.totalScore >= 0 ? "text-emerald-700" : "text-destructive"}`}>

--- a/components/stats-print/StatsSummaryTable.tsx
+++ b/components/stats-print/StatsSummaryTable.tsx
@@ -2,8 +2,11 @@ import type { PlayerStats } from "@/lib/stats";
 import { RANK_BADGE } from "@/lib/stats-rank-theme";
 import React from "react";
 
+type RankSets = { first: string[]; second: string[]; third: string[] };
+
 interface StatsSummaryTableProps {
   stats: PlayerStats[];
+  topSets: Record<string, RankSets>;
   title: string;
 }
 
@@ -15,7 +18,22 @@ function score(v: number) {
   return String(v);
 }
 
-export const StatsSummaryTable: React.FC<StatsSummaryTableProps> = ({ stats, title }) => (
+function medalBadge(topSets: Record<string, RankSets>, metric: string, playerName: string, value: React.ReactNode) {
+  const sets = topSets[metric];
+  if (!sets) return <>{value}</>;
+  let rank = 0;
+  if (sets.first?.includes(playerName)) rank = 1;
+  else if (sets.second?.includes(playerName)) rank = 2;
+  else if (sets.third?.includes(playerName)) rank = 3;
+  if (!rank) return <>{value}</>;
+  return (
+    <span className={`inline-flex items-center gap-0.5 rounded px-1 font-bold ${RANK_BADGE[rank]}`}>
+      {value}
+    </span>
+  );
+}
+
+export const StatsSummaryTable: React.FC<StatsSummaryTableProps> = ({ stats, topSets, title }) => (
   <section className="mb-6">
     <h2 className="font-semibold mb-2 text-emerald-900">{title}</h2>
     <div className="overflow-x-auto">
@@ -55,24 +73,24 @@ export const StatsSummaryTable: React.FC<StatsSummaryTableProps> = ({ stats, tit
                 )}
               </td>
               <td className="px-2 py-0 align-middle leading-4 whitespace-nowrap">{p.name}</td>
-              <td className="px-2 py-0 text-right tabular-nums align-middle leading-4">{p.games}</td>
+              <td className="px-2 py-0 text-right tabular-nums align-middle leading-4">{medalBadge(topSets, "games", p.name, p.games)}</td>
               <td className={`px-2 py-0 text-right tabular-nums align-middle leading-4 ${p.totalScore >= 0 ? "text-emerald-700" : "text-destructive"}`}>
                 {score(p.totalScore)}
               </td>
-              <td className="px-2 py-0 text-right align-middle leading-4">{p.topCount}</td>
-              <td className="px-2 py-0 text-right align-middle leading-4">{p.lastCount}</td>
-              <td className="px-2 py-0 text-right align-middle leading-4">{pct(p.topRate)}</td>
-              <td className="px-2 py-0 text-right align-middle leading-4">{pct(p.secondRate)}</td>
-              <td className="px-2 py-0 text-right align-middle leading-4">{pct(p.thirdRate)}</td>
-              <td className="px-2 py-0 text-right align-middle leading-4">{pct(p.lastAvoidanceRate)}</td>
-              <td className="px-2 py-0 text-right align-middle leading-4">{p.tobashiCount}</td>
-              <td className="px-2 py-0 text-right align-middle leading-4">{p.tobiCount}</td>
-              <td className="px-2 py-0 text-right align-middle leading-4">{p.yakitoriCount}</td>
-              <td className="px-2 py-0 text-right align-middle leading-4">{p.yakumanCount}</td>
-              <td className="px-2 py-0 text-right align-middle leading-4">{pct(p.tobashiRate)}</td>
-              <td className="px-2 py-0 text-right align-middle leading-4">{pct(p.tobiAvoidanceRate)}</td>
-              <td className="px-2 py-0 text-right align-middle leading-4">{pct(p.yakitoriAvoidanceRate)}</td>
-              <td className="px-2 py-0 text-right align-middle leading-4">{pct(p.setaiRate)}</td>
+              <td className="px-2 py-0 text-right align-middle leading-4">{medalBadge(topSets, "topCount", p.name, p.topCount)}</td>
+              <td className="px-2 py-0 text-right align-middle leading-4">{medalBadge(topSets, "lastCount", p.name, p.lastCount)}</td>
+              <td className="px-2 py-0 text-right align-middle leading-4">{medalBadge(topSets, "topRate", p.name, pct(p.topRate))}</td>
+              <td className="px-2 py-0 text-right align-middle leading-4">{medalBadge(topSets, "secondRate", p.name, pct(p.secondRate))}</td>
+              <td className="px-2 py-0 text-right align-middle leading-4">{medalBadge(topSets, "thirdRate", p.name, pct(p.thirdRate))}</td>
+              <td className="px-2 py-0 text-right align-middle leading-4">{medalBadge(topSets, "lastAvoidanceRate", p.name, pct(p.lastAvoidanceRate))}</td>
+              <td className="px-2 py-0 text-right align-middle leading-4">{medalBadge(topSets, "tobashiCount", p.name, p.tobashiCount)}</td>
+              <td className="px-2 py-0 text-right align-middle leading-4">{medalBadge(topSets, "tobiCount", p.name, p.tobiCount)}</td>
+              <td className="px-2 py-0 text-right align-middle leading-4">{medalBadge(topSets, "yakitoriCount", p.name, p.yakitoriCount)}</td>
+              <td className="px-2 py-0 text-right align-middle leading-4">{medalBadge(topSets, "yakumanCount", p.name, p.yakumanCount)}</td>
+              <td className="px-2 py-0 text-right align-middle leading-4">{medalBadge(topSets, "tobashiRate", p.name, pct(p.tobashiRate))}</td>
+              <td className="px-2 py-0 text-right align-middle leading-4">{medalBadge(topSets, "tobiAvoidanceRate", p.name, pct(p.tobiAvoidanceRate))}</td>
+              <td className="px-2 py-0 text-right align-middle leading-4">{medalBadge(topSets, "yakitoriAvoidanceRate", p.name, pct(p.yakitoriAvoidanceRate))}</td>
+              <td className="px-2 py-0 text-right align-middle leading-4">{medalBadge(topSets, "setaiRate", p.name, pct(p.setaiRate))}</td>
             </tr>
           ))}
         </tbody>


### PR DESCRIPTION
## 設計概要
Issue #215: PDF出力（/stats/print）の成績集計テーブルの順位列に、成績集計画面と同じランクバッジを表示する。

## 実装概要
- `components/stats-print/StatsSummaryTable.tsx` に `RANK_BADGE` をインポート
- 順位 `<td>` を条件分岐に変更: 1〜3位はバッジ付き `<span>`、4位以降はプレーンテキスト
- バッジスタイル: 1位=黄色、2位=グレー、3位=オレンジ（`lib/stats-rank-theme.ts` の既存定義に準拠）

## 実行した検証コマンドと結果
```
npm run build → ✅ 成功
npm test      → ✅ 4/4 pass
```

## 手動動作確認の内容
- Playwright ブラウザで http://localhost:3001/stats/print を表示
- 1位: 黄色バッジ、2位: グレーバッジ、3位: オレンジバッジが表示されることを目視確認
- 4位以降はプレーンテキストで表示されることを確認

## 既知の未解決事項
なし

Closes #215

## Worklog
- worklog: .worklog/logs/2026-05-06.md に記録を追記済み
- worklog: 作業単位（#213/#214/#215）でエントリを分割して記録