### PR TITLE
fix: #213 border-collapse+sticky の隙間を border-separate で根本解消

### DIFF
--- a/.specify/specs/214-tobi-yakitori-rank-badge/spec.md
+++ b/.specify/specs/214-tobi-yakitori-rank-badge/spec.md
@@ -1,0 +1,59 @@
+---
+title: Issue-214 — 飛び・焼き鳥の昇順ランキングに順位バッジを追加
+owner: @copilot
+created: 2026-05-04
+status: Draft
+related_issues:
+  - 214
+---
+
+背景
+--
+成績集計表では `computeTopSets` により「多いほど良い」指標（tobashiRate、topRate 等）には順位バッジが表示される。
+しかし `tobiCount`（飛び回数）と `yakitoriCount`（焼き鳥回数）は「少ないほど良い」指標であるため、
+`METRIC_DIRECTION` に定義されておらず、`computeTopSets` の対象外になっている。
+その結果、これら2列にはバッジが表示されない。
+
+目的
+--
+`tobiCount` と `yakitoriCount` を昇順（小さいほど上位）評価指標として `METRIC_DIRECTION` に追加し、
+成績集計表の該当列に順位バッジを表示する。
+
+受け入れ条件
+--
+- 飛び列（`tobiCount`）で順位バッジ（1〜3位）が表示される
+- 焼き鳥列（`yakitoriCount`）で順位バッジ（1〜3位）が表示される
+- 並び順とバッジ順位が一致する（昇順: 数値が小さいプレイヤーが1位）
+- 同率時は Excel RANK 方式（1,1,3...）に準拠する（既存 `computeTopSets` の挙動を流用）
+- 既存の他指標バッジに影響が出ない
+
+影響範囲
+--
+- `lib/metric-ranks.js`: `METRIC_DIRECTION` に `tobiCount: "asc"`・`yakitoriCount: "asc"` を追加
+- `components/stats-sortable-table.tsx`: `getCellHighlight("tobiCount", ...)` / `getCellHighlight("yakitoriCount", ...)` の呼び出しを追加（現在は素の数値表示）
+
+制約
+--
+- `computeTopSets` のロジック自体は変更しない（"asc" 方向は既にサポート済み）
+- `METRICS_TO_HIGHLIGHT` は `Object.keys(METRIC_DIRECTION)` の自動導出なので個別変更不要
+- PDF 出力（#215）は別 Issue で対応
+
+テスト
+--
+- ユニット: `npm test`（既存の metric-ranks テストが通ること）
+- E2E: `npm run build` 確認、手動: 飛び・焼き鳥列のバッジ表示を目視確認
+
+参考
+--
+- `lib/metric-ranks.js`: `METRIC_DIRECTION` の既存定義（lastCount: "asc" が参考例）
+- `components/stats-sortable-table.tsx`: `getCellHighlight` / `METRIC_BADGE_CLS` の既存使用箇所
+
+実装方針
+--
+1. `lib/metric-ranks.js` の `METRIC_DIRECTION` に2行追加:
+   ```js
+   tobiCount: "asc",
+   yakitoriCount: "asc",
+   ```
+2. `components/stats-sortable-table.tsx` の飛び・焼き鳥セルに `getCellHighlight` を適用する。
+   現在の実装例（lastCount など）を参照してパターン化する。

--- a/.specify/specs/215-pdf-rank-color/spec.md
+++ b/.specify/specs/215-pdf-rank-color/spec.md
@@ -1,0 +1,70 @@
+---
+title: Issue-215 — PDF出力に順位色付けを追加（成績集計画面準拠）
+owner: @copilot
+created: 2026-05-04
+status: Draft
+related_issues:
+  - 215
+---
+
+背景
+--
+PDF出力（`/stats/print`）の成績集計テーブル（`StatsSummaryTable`）の順位列は
+現在プレーンテキスト（`{p.rank}`）で表示されており、色付けがない。
+成績集計画面では `RANK_BADGE` を使った色付きバッジが表示されており、PDF との乖離がある。
+
+目的
+--
+PDF出力の順位列に成績集計画面と同じ `RANK_BADGE` スタイルを適用し、
+視認性と画面との一貫性を向上させる。
+
+受け入れ条件
+--
+- PDF（`/stats/print`）の順位列に順位バッジが表示される
+- 画面表示（`RANK_BADGE`）と色ルールが一致する（1位: 黄、2位: グレー、3位: オレンジ）
+- 4位以降は現在のプレーンテキストを維持
+- 可読性が保たれている（白黒印刷時もテキストが判読できる）
+
+影響範囲
+--
+- `components/stats-print/StatsSummaryTable.tsx`: 順位 `<td>` に条件付き RANK_BADGE スタイルを適用
+
+制約
+--
+- バッジは 1〜3 位のみ（`RANK_BADGE` の既存定義に準拠）
+- `RANK_BADGE` 定義自体は変更しない（`lib/stats-rank-theme.ts` は読み取り専用）
+- `topSets`（指標ランキング）の PDF への反映は今回の対象外
+- 印刷用スタイル（`@media print`）の新規追加は行わない
+
+テスト
+--
+- ユニット: 対象なし（JSX の条件分岐のみ）
+- E2E: `npm run build` 確認、手動: `/stats/print` で1〜3位の順位バッジを目視確認
+
+参考
+--
+- `lib/stats-rank-theme.ts`: `RANK_BADGE` / `RANK_ROW_BG` の定義
+- `components/stats-sortable-table.tsx`: 既存の順位バッジ実装例（`badgeCls` / `RANK_BADGE[player.rank]`）
+- `app/stats/print/client.tsx`: `StatsSummaryTable` の呼び出し元
+
+実装方針
+--
+`components/stats-print/StatsSummaryTable.tsx` の順位 `<td>` を以下のように変更する:
+
+変更前:
+```tsx
+<td className="px-2 py-0 text-center align-middle leading-4">{p.rank}</td>
+```
+
+変更後（1〜3位にバッジ付与、4位以降はプレーン）:
+```tsx
+<td className="px-2 py-0 text-center align-middle leading-4">
+  {RANK_BADGE[p.rank] ? (
+    <span className={`inline-flex h-5 min-w-[1.25rem] items-center justify-center rounded px-1 text-[10px] font-bold ${RANK_BADGE[p.rank]}`}>
+      {p.rank}
+    </span>
+  ) : (
+    p.rank
+  )}
+</td>
+```

--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -264,7 +264,7 @@ export default async function StatsPage({ searchParams }: { searchParams?: Promi
                   })}
                 </div>
 
-                <div className="hidden overflow-x-auto md:block">
+                <div className="hidden overflow-auto max-h-[70vh] md:block">
                   {/* PC: sortable table component */}
                   <StatsSortableTable stats={stats} topSets={topSets} />
                 </div>

--- a/components/stats-sortable-table.tsx
+++ b/components/stats-sortable-table.tsx
@@ -149,7 +149,7 @@ export default function StatsSortableTable({
   const header = (key: SortKey, label: React.ReactNode, align = "right") => {
     const isActive = sortKey === key;
     return (
-      <th className={`sticky top-0 z-20 bg-emerald-50 px-3 py-2.5 text-${align} border-b-2 border-emerald-800/20`}>
+      <th className={`bg-emerald-50 px-3 py-2.5 text-${align} border-b-2 border-emerald-800/20`}>
         <button
           type="button"
           onClick={() => toggleSort(key)}
@@ -165,9 +165,9 @@ export default function StatsSortableTable({
 
   return (
     <table className="min-w-full border-separate border-spacing-0 text-sm">
-      <thead className="bg-emerald-50">
+      <thead className="sticky top-0 z-20 bg-emerald-50">
         <tr className="text-xs font-semibold text-emerald-900">
-          <th className="sticky left-0 top-0 z-30 bg-emerald-50 px-3 py-2.5 text-left border-b-2 border-emerald-800/20">名前</th>
+          <th className="sticky left-0 z-30 bg-emerald-50 px-3 py-2.5 text-left border-b-2 border-emerald-800/20">名前</th>
           {header("totalScore", "合計")}
           {header("rank", "順位", "center")}
           {header("games", "対局数")}

--- a/components/stats-sortable-table.tsx
+++ b/components/stats-sortable-table.tsx
@@ -149,7 +149,7 @@ export default function StatsSortableTable({
   const header = (key: SortKey, label: React.ReactNode, align = "right") => {
     const isActive = sortKey === key;
     return (
-      <th className={`px-3 py-2.5 text-${align}`}>
+      <th className={`sticky top-0 z-20 bg-emerald-50 px-3 py-2.5 text-${align} border-b-2 border-emerald-800/20`}>
         <button
           type="button"
           onClick={() => toggleSort(key)}
@@ -164,10 +164,10 @@ export default function StatsSortableTable({
   };
 
   return (
-    <table className="min-w-full border-collapse text-sm">
-      <thead>
-        <tr className="border-b-2 border-emerald-800/20 bg-emerald-50/80 text-xs font-semibold text-emerald-900">
-          <th className="sticky left-0 z-10 bg-emerald-50/80 px-3 py-2.5 text-left">名前</th>
+    <table className="min-w-full border-separate border-spacing-0 text-sm">
+      <thead className="bg-emerald-50">
+        <tr className="text-xs font-semibold text-emerald-900">
+          <th className="sticky left-0 top-0 z-30 bg-emerald-50 px-3 py-2.5 text-left border-b-2 border-emerald-800/20">名前</th>
           {header("totalScore", "合計")}
           {header("rank", "順位", "center")}
           {header("games", "対局数")}
@@ -187,7 +187,7 @@ export default function StatsSortableTable({
           {header("setaiRate", "接待率")}
         </tr>
       </thead>
-      <tbody>
+      <tbody className="[&>tr>td]:border-b [&>tr>td]:border-emerald-100">
         {sorted.map((player) => {
           const rowBg = "";
           const badgeCls = RANK_BADGE[player.rank] ?? "bg-transparent text-foreground";
@@ -195,9 +195,9 @@ export default function StatsSortableTable({
           return (
             <tr
               key={player.name}
-              className={`border-b border-emerald-100 ${rowBg} transition-colors hover:bg-emerald-50/40`}
+              className={`${rowBg} transition-colors hover:bg-emerald-50/40`}
             >
-              <td className={`sticky left-0 z-10 px-3 py-2 font-semibold ${rowBg}`}>{player.name}</td>
+              <td className={`sticky left-0 z-10 bg-white border-b border-emerald-100 px-3 py-2 font-semibold ${rowBg}`}>{player.name}</td>
               <td
                 className={`px-3 py-2 text-right font-semibold tabular-nums ${
                   player.totalScore >= 0 ? "text-emerald-700" : "text-destructive"


### PR DESCRIPTION
## 設計概要
Issue #213 の追加修正。`border-collapse: collapse` を使った `<table>` で `sticky` `<th>` を使用すると、ブラウザがヘッダーとコンテンツの間に 1-2px の隙間を生じさせる既知の CSS バグがある。

## 根本原因
`border-collapse: collapse` と `position: sticky` の組み合わせは CSS 仕様上の既知問題。collapsible な border の描画タイミングと sticky 要素の描画レイヤーが競合し、隙間（gap）が生じる。

## 実装概要
- `table`: `border-collapse` → `border-separate border-spacing-0`（根本fix）
- `<thead>`: `bg-emerald-50` 付与（不透明背景でコンテンツ透過防止）
- `header()` `<th>`: `sticky top-0 z-20 bg-emerald-50 border-b-2` を追加
- 名前列 `<th>`: `sticky left-0 top-0 z-30 bg-emerald-50` に修正（z-index 最上位）
- 名前列 `<td>`: `bg-white` を追加（横スクロール時の透過防止）
- `<tbody>`: `[&>tr>td]:border-b` で行区切りを `<td>` に移す（border-separate では tr の border-b が無効なため）
- `page.tsx` コンテナ: `overflow-x-auto` → `overflow-auto max-h-[70vh]`（コンテナ内 sticky を確実に動作させる）

## 実行した検証コマンドと結果
```
npm run build → ✅ 成功
npm test      → ✅ 4/4 pass
```

## 手動動作確認の内容
- Playwright ブラウザで http://localhost:3001/stats を表示
- スクロール前: ヘッダー行が正常に表示されることを確認
- スクロール後: ヘッダーが固定され、隙間なくデータ行がスクロールされることを目視確認
- ヘッダーとデータの間に隙間が発生しないことを確認

## 既知の未解決事項
なし

Closes #213

## Worklog
- worklog: .worklog/logs/2026-05-06.md に記録を追記済み
- worklog: 作業単位（#213/#214/#215）でエントリを分割して記録