### PR TITLE
feat: Issue #121 相性表（プレーヤー間戦績マトリクス）を追加

### DIFF
--- a/.specify/specs/121-compatibility-matrix/plan.md
+++ b/.specify/specs/121-compatibility-matrix/plan.md
@@ -1,0 +1,162 @@
+# Implementation Plan: 相性表（プレーヤー間戦績マトリクス）
+
+**Branch**: `feature/issue-121-compatibility-matrix` | **Date**: 2026-05-08  
+**Spec**: `.specify/specs/121-compatibility-matrix/spec.md`  
+**Issue**: #121
+
+---
+
+## Summary
+
+プレーヤー間の対戦戦績（勝・負・分け・勝率）を N×N マトリクスで閲覧できる新規ページ `/compatibility` を追加する。  
+既存の `fetchMatchResults` / `DateRangeFilter` コンポーネントを最大限再利用し、最小差分で実装する。
+
+---
+
+## Technical Context
+
+**Language/Version**: TypeScript 5 / Node.js 20  
+**Framework**: Next.js 15 App Router (Server Components)  
+**Primary Dependencies**: Supabase JS Client, Tailwind CSS, shadcn/ui  
+**Storage**: Supabase (PostgreSQL) — `games` テーブル  
+**Testing**: Vitest（既存設定）  
+**Target Platform**: Web (Vercel 想定)  
+**Performance Goals**: フィルタ範囲内ゲーム件数が数百〜千件程度、インメモリ集計で十分  
+**Constraints**: 既存コンポーネント・パターンを尊重、最小差分
+
+---
+
+## 実装方針
+
+### 1. データ取得・集計（`lib/compatibility.ts`）
+
+既存の `fetchMatchResults(startDate, endDate, { tournamentId })` を呼び出し、返却された `MatchResult[]` をインメモリで集計する。
+
+```
+MatchResult.players: MatchPlayer[]
+  - name: string
+  - rank: number (1始まり、小さい方が上位)
+```
+
+各ゲームの `players` 配列から全ペア組み合わせ `(i, j)` を列挙し、`rank` を比較して勝敗カウントを更新する。
+
+```typescript
+export type MatchupRecord = {
+  wins: number;
+  losses: number;
+  draws: number;
+};
+
+export type CompatibilityResult = {
+  players: string[];                        // ソート済み全プレーヤーリスト
+  matrix: Map<string, Map<string, MatchupRecord>>;
+};
+
+export function computeWinRate(r: MatchupRecord): number {
+  const total = r.wins + r.losses;
+  return total === 0 ? 0 : (r.wins / total) * 100;
+}
+
+export async function fetchCompatibilityMatrix(
+  startDate?: string,
+  endDate?: string,
+  options: { tournamentId?: number } = {}
+): Promise<{ result: CompatibilityResult | null; error: string | null }>
+```
+
+### 2. ページ（`app/compatibility/page.tsx`）
+
+`app/stats/page.tsx` に倣った Server Component として実装する。
+
+- `getCurrentSession()` でセッション取得（ミドルウェアが認証を保証済みだが、ヘッダー表示に必要）
+- `resolveFilterParams()` でクエリパラメータを解析（`minGames` は使用しない）
+- `fetchCompatibilityMatrix()` でデータ取得
+- `DateRangeFilter` に `showMinGames={false}` を渡す（`/matches` と同様の方法）
+- マトリクステーブルを JSX で描画（Server Component 内でインライン実装）
+
+### 3. ヘッダー変更（`components/app-header.tsx`）
+
+```typescript
+// Before
+type NavTarget = "input" | "matches" | "stats" | "admin";
+
+// After
+type NavTarget = "input" | "matches" | "stats" | "compatibility" | "admin";
+```
+
+- `navClass` / `handleNavClick` は "compatibility" を `Exclude<NavTarget, "admin">` で自動処理
+- ナビリンクに `<Link href="/compatibility" ...>相性表</Link>` を追加（stats の次）
+
+---
+
+## Project Structure
+
+```text
+.specify/specs/121-compatibility-matrix/
+├── spec.md          ← 作成済み
+├── plan.md          ← このファイル
+└── tasks.md         ← tasks コマンドで生成
+
+app/
+└── compatibility/
+    └── page.tsx     ← 新規
+
+lib/
+└── compatibility.ts ← 新規
+
+components/
+└── app-header.tsx   ← NavTarget 型追加 + リンク追加
+```
+
+---
+
+## 既存コンポーネント再利用方針
+
+| コンポーネント/関数 | 再利用方法 |
+|---|---|
+| `fetchMatchResults` | そのまま呼び出し。フィルタ（日付・トーナメント）を渡す |
+| `resolveFilterParams` | そのまま呼び出し。`minGamesRaw` は渡さない |
+| `DateRangeFilter` | `showMinGames={false}` で呼び出し |
+| `fetchMatchDates` | availableDates 取得に使用 |
+| `fetchTournamentOptions` | トーナメント一覧取得に使用 |
+| `getCurrentSession` | セッション取得に使用 |
+| `AppHeader` | `current="compatibility"` を渡す |
+
+---
+
+## セルレンダリングロジック
+
+```typescript
+function renderCell(record: MatchupRecord | undefined, isSelf: boolean): string {
+  if (isSelf) return "-";
+  if (!record) return "-";          // 対局なし
+  const { wins, losses, draws } = record;
+  if (wins === 0 && losses === 0 && draws === 0) return "-";
+  const drawPart = draws > 0 ? `${draws}分け` : "";
+  const wr = computeWinRate(record);
+  return `${wins}勝${losses}敗${drawPart}\n${wr.toFixed(1)}%`;
+}
+```
+
+---
+
+## テスト方針
+
+`lib/compatibility.ts` の `buildCompatibilityMatrix`（内部ヘルパー）をユニットテスト対象とする。
+
+テストケース：
+1. 4人ゲームで rank 1 < rank 2 のペア → 勝ち1
+2. 同着順 → 分け1
+3. 空の matches → 空のマトリクス
+4. 0除算回避（wins + losses = 0）→ 勝率 0%
+
+---
+
+## リスク・注意事項
+
+| リスク | 対策 |
+|---|---|
+| `games` テーブルの `rank` が NULL のレコード | ペア処理時に `rank` が falsy なら skip |
+| プレーヤー名の表記揺れ（スペース等） | `name.trim()` を適用（既存の fetchMatchResults が trim しているか確認して合わせる） |
+| プレーヤー数が多い場合のテーブル幅 | `overflow-x-auto` でラップ |
+| NavTarget 型が他ファイルで参照されている場合 | `app-header.tsx` 内の型のみ変更。他に参照なし（Explore 調査済み） |

--- a/.specify/specs/121-compatibility-matrix/spec.md
+++ b/.specify/specs/121-compatibility-matrix/spec.md
@@ -1,0 +1,153 @@
+# Feature Specification: 相性表（プレーヤー間戦績マトリクス）
+
+**Feature Branch**: `feature/issue-121-compatibility-matrix`  
+**Created**: 2026-05-08  
+**Status**: Draft  
+**Issue**: #121
+
+---
+
+## User Scenarios & Testing
+
+### User Story 1 - 相性表マトリクスの閲覧 (Priority: P1)
+
+ログイン済みユーザーが「相性表」ページを開き、フィルタ条件（全期間デフォルト）で全プレーヤー間の勝敗戦績をマトリクス形式で確認する。
+
+**Why this priority**: 本機能の中核であり、これなしで他のストーリーは成立しない。
+
+**Independent Test**: `/compatibility` にアクセスしてマトリクス表が表示されること
+
+**Acceptance Scenarios**:
+
+1. **Given** ログイン済みユーザーがいる、**When** `/compatibility` へアクセス、**Then** 行・列にプレーヤー名が表示されたマトリクス表が描画される
+2. **Given** プレーヤー A が rank1、プレーヤー B が rank3 で同一ゲームに参加した、**When** 相性表を表示、**Then** A vs B セル: "1勝0敗 / 100%"、B vs A セル: "0勝1敗 / 0%"
+3. **Given** A と B が同着順（同一ゲームで rankA === rankB）、**When** 相性表を表示、**Then** A vs B セル: "0勝0敗1分け / 0%"（分け数は0以外のとき表示）
+4. **Given** 行と列が同一プレーヤー（対角線）、**When** 相性表を表示、**Then** セルに「-」を表示
+5. **Given** 未ログインユーザー、**When** `/compatibility` へアクセス、**Then** ログインページへリダイレクト
+
+---
+
+### User Story 2 - フィルタによる絞り込み (Priority: P2)
+
+ユーザーが日付範囲・トーナメントフィルタを変更し、特定期間・大会のみの相性データを確認する。
+
+**Why this priority**: 成績集計と同様のフィルタ体験を提供することで一貫したUXが得られる。
+
+**Independent Test**: フィルタ変更後にURLパラメータが更新されマトリクスが再計算されること
+
+**Acceptance Scenarios**:
+
+1. **Given** 相性表が表示されている、**When** DateRangeFilter で "2026年" を選択、**Then** 2026年内のゲームのみを対象とした戦績が再表示される
+2. **Given** 特定トーナメントを選択、**When** 相性表を表示、**Then** そのトーナメントの試合のみを集計した戦績が表示される
+
+---
+
+### User Story 3 - ヘッダーからの遷移 (Priority: P3)
+
+グローバルヘッダーの「相性表」ボタンから相性表ページへ遷移できる。
+
+**Why this priority**: アプリ内ナビゲーションの一貫性に必要。
+
+**Acceptance Scenarios**:
+
+1. **Given** ログイン済みユーザー、**When** ヘッダーの「相性表」をクリック、**Then** `/compatibility` へ遷移し、ボタンがアクティブ状態になる
+
+---
+
+### Edge Cases
+
+- 対局データが0件の場合 → 「データがありません」等のメッセージを表示
+- プレーヤーが1人のみ（マトリクスが 1×1）→ 正常表示（対角線のみ `-`）
+- プレーヤー間でゲームが存在しないペア（両者が同じゲームに一度も参加していない）→ セルを空（`-`）表示
+- 勝数・敗数が両方0（分けのみ）→ 勝率 0%
+- wins + losses = 0 の場合（分けのみ）→ 0除算回避: 勝率 0%
+
+---
+
+## Requirements
+
+### 機能要件
+
+| ID | 要件 |
+|---|---|
+| F-01 | `/compatibility` に新規ページを追加する |
+| F-02 | 行プレーヤー × 列プレーヤーのマトリクス表を表示する |
+| F-03 | 各セルに「X勝X敗（X分け） / 勝率X%」を表示する。分けが0の場合は分け表示を省略 |
+| F-04 | 勝率 = 勝数 ÷ (勝数 + 敗数) × 100。wins+losses=0 の場合は 0% |
+| F-05 | 対角線（同一プレーヤー）セルは「-」を表示 |
+| F-06 | 対局データが存在しないペアのセルは「-」を表示 |
+| F-07 | DateRangeFilter（既存コンポーネント）をそのまま利用し、成績集計と同等のフィルタを提供 |
+| F-08 | グローバルヘッダーに「相性表」ナビリンクを追加 |
+| F-09 | 未ログインユーザーはアクセス不可（既存ミドルウェアで実現）|
+| F-10 | admin / editor / viewer 全ロールが閲覧可能 |
+
+### 非機能要件
+
+| ID | 要件 |
+|---|---|
+| N-01 | モバイル・デスクトップともにスクロール対応（テーブルは `overflow-x-auto` でラップ）|
+| N-02 | 既存の Tailwind / コンポーネントスタイルに準拠 |
+| N-03 | Server Component + Server Action パターン（stats ページと同様）|
+
+---
+
+## 勝敗判定ロジック
+
+同一ゲーム内の全プレーヤー組み合わせペア `(i, j)` を列挙（`i < j`）し、順位を比較する。
+
+```
+games テーブルのカラム: player1〜player4 (TEXT), rank1〜rank4 (SMALLINT)
+player_count が 3 なら player4/rank4 は NULL
+```
+
+各ゲームで有効プレーヤーリスト（NULL 除外）を生成し、全ペア組み合わせを評価：
+- `rank_i < rank_j` → A[i] の勝ち、A[j] の負け
+- `rank_i > rank_j` → A[i] の負け、A[j] の勝ち
+- `rank_i === rank_j` → 分け（両者に +1 draw）
+
+集計構造：
+```typescript
+type MatchupRecord = {
+  wins: number;
+  losses: number;
+  draws: number;
+};
+// matrix[rowPlayer][colPlayer] = MatchupRecord
+type CompatibilityMatrix = Map<string, Map<string, MatchupRecord>>;
+```
+
+---
+
+## 画面レイアウト
+
+```
+[ヘッダー] スコア入力 | 対局履歴 | 成績集計 | 相性表 | 管理画面
+─────────────────────────────────────────────────────
+[DateRangeFilter] （成績集計と同一 props 構成）
+─────────────────────────────────────────────────────
+相性表
+         | A | B | C | D |
+    ─────┼───┼───┼───┼───┤
+      A  | - |2勝1敗|...|...|
+         |   |67%|   |   |
+    ─────┼───┼───┼───┼───┤
+      B  |..| - |...|...|
+    ...
+```
+
+---
+
+## 変更ファイル一覧（予定）
+
+| ファイル | 種別 | 概要 |
+|---|---|---|
+| `app/compatibility/page.tsx` | 新規 | 相性表ページ（Server Component） |
+| `lib/compatibility.ts` | 新規 | 相性データ算出ロジック |
+| `components/app-header.tsx` | 変更 | NavTarget に "compatibility" 追加、ナビリンク追加 |
+| `lib/authorization.ts` または型定義 | 変更 | NavTarget 型へ "compatibility" を追加（必要な場合） |
+
+---
+
+## 未解決事項
+
+- なし（確認済み）

--- a/.specify/specs/121-compatibility-matrix/tasks.md
+++ b/.specify/specs/121-compatibility-matrix/tasks.md
@@ -1,0 +1,117 @@
+# Tasks: 相性表（プレーヤー間戦績マトリクス）
+
+**Branch**: `feature/issue-121-compatibility-matrix`  
+**Spec**: `.specify/specs/121-compatibility-matrix/spec.md`  
+**Plan**: `.specify/specs/121-compatibility-matrix/plan.md`  
+**Issue**: #121
+
+---
+
+## Phase 0: 準備
+
+- [ ] **T-00** ブランチ作成  
+  ```bash
+  git checkout develop
+  git pull origin develop
+  git checkout -b feature/issue-121-compatibility-matrix
+  ```
+
+- [ ] **T-01** worklog 起票  
+  ```bash
+  npm run worklog:start -- \
+    --summary "Issue #121 相性表 実装開始" \
+    --reason "プレーヤー間戦績マトリクスの新規画面追加" \
+    --tags "issue-121,implementation,worklog"
+  ```
+
+---
+
+## Phase 1: ロジック実装
+
+- [ ] **T-10** `lib/compatibility.ts` を新規作成  
+  - `MatchupRecord` 型定義（wins / losses / draws）
+  - `CompatibilityResult` 型定義（players: string[], matrix: Map<string, Map<string, MatchupRecord>>）
+  - `computeWinRate(r: MatchupRecord): number` — wins/(wins+losses)*100、0除算は0
+  - `buildCompatibilityMatrix(matches: MatchResult[]): CompatibilityResult` — インメモリ集計（export してテスト対象にする）
+  - `fetchCompatibilityMatrix(startDate?, endDate?, options): Promise<...>` — fetchMatchResults を呼び出し、buildCompatibilityMatrix に渡す
+
+---
+
+## Phase 2: ユニットテスト
+
+- [ ] **T-20** `test/compatibility.test.ts` を新規作成  
+  - 4人ゲームの rank 比較 → 勝敗カウント
+  - 同着順 → 分けカウント
+  - 空の matches → 空のマトリクス
+  - wins+losses=0 → 勝率 0%
+  - プレーヤー名 trim の確認
+
+---
+
+## Phase 3: ページ実装
+
+- [ ] **T-30** `app/compatibility/page.tsx` を新規作成  
+  - metadata（タイトル: "相性表 | 麻雀成績入力"）
+  - `export const dynamic = "force-dynamic"`
+  - `getCurrentSession()` でセッション取得
+  - `resolveFilterParams()` でクエリパラメータ解析（minGames なし）
+  - `fetchTournamentOptions()`, `fetchMatchDates()`, `fetchCompatibilityMatrix()` を並列呼び出し（Promise.all）
+  - `AppHeader current="compatibility"` を設置
+  - `DateRangeFilter` を `showMinGames={false}` で設置、`actionPath="/compatibility"`
+  - マトリクステーブルを JSX で描画
+    - `overflow-x-auto` ラップ
+    - ヘッダー行・列にプレーヤー名
+    - 各セル: 勝敗文字列 + 勝率（改行）
+    - 対角線・対局なしセル: `-`
+    - データなし: 「データがありません」メッセージ
+
+---
+
+## Phase 4: ヘッダー変更
+
+- [ ] **T-40** `components/app-header.tsx` の `NavTarget` 型に `"compatibility"` を追加  
+  ```diff
+  - type NavTarget = "input" | "matches" | "stats" | "admin";
+  + type NavTarget = "input" | "matches" | "stats" | "compatibility" | "admin";
+  ```
+
+- [ ] **T-41** ナビリンク追加（stats の直後）  
+  ```tsx
+  <Link href="/compatibility" className={navClass("compatibility")} onClick={handleNavClick("compatibility")} aria-busy={navigatingTo === "compatibility"} aria-disabled={navigatingTo === "compatibility"}>
+    相性表
+  </Link>
+  ```
+
+---
+
+## Phase 5: 検証
+
+- [ ] **T-50** `npm run build` — ビルド成功を確認
+- [ ] **T-51** `npm run lint` — Lint エラーなしを確認  
+- [ ] **T-52** `npm test` — テスト通過を確認（T-20 の新規テストを含む）
+- [ ] **T-53** 手動動作確認  
+  - ヘッダーに「相性表」が表示されること
+  - `/compatibility` にアクセスしてマトリクスが表示されること
+  - フィルタ変更で URL パラメータが更新されマトリクスが再集計されること
+  - 対角線セルが「-」になること
+  - 未ログインでアクセスするとログインページへリダイレクトされること
+
+---
+
+## Phase 6: コミット・PR
+
+- [ ] **T-60** `git add` + `git commit`（buildが成功していること）
+- [ ] **T-61** `git push origin feature/issue-121-compatibility-matrix`
+- [ ] **T-62** PR 作成（`gh pr create`、マージ先: `develop`）  
+  PR 本文必須項目: 設計概要 / 実装概要 / 検証コマンドと結果 / 手動動作確認 / 既知の未解決事項 / Worklog
+
+---
+
+## 依存関係
+
+```
+T-00 → T-01 → T-10 → T-20 (並列可: T-30, T-20)
+T-10 → T-30
+T-30 → T-40
+T-40, T-41 → T-50 → T-51 → T-52 → T-53 → T-60 → T-61 → T-62
+```

--- a/app/compatibility/page.tsx
+++ b/app/compatibility/page.tsx
@@ -1,0 +1,163 @@
+import type { Metadata } from "next";
+import { Suspense } from "react";
+
+import { AppHeader } from "@/components/app-header";
+import DateRangeFilter from "@/components/date-range-filter";
+import { FlashMessage } from "@/components/flash-message";
+import { resolveFilterParams } from "@/lib/filter-params";
+import { fetchCompatibilityMatrix, computeWinRate, type MatchupRecord } from "@/lib/compatibility";
+import { fetchMatchDates } from "@/lib/matches";
+import { getCurrentSession } from "@/lib/session";
+import { fetchTournamentOptions } from "@/lib/tournaments";
+
+export const metadata: Metadata = {
+  title: "相性表 | 麻雀成績入力",
+  description: "プレーヤー間の対戦戦績（勝・負・分け・勝率）をマトリクス形式で表示します",
+};
+
+export const dynamic = "force-dynamic";
+
+type SearchParams = { [key: string]: string | string[] | undefined } | undefined;
+
+function renderCellText(record: MatchupRecord | undefined): string | null {
+  if (!record) return null;
+  const { wins, losses, draws } = record;
+  if (wins === 0 && losses === 0 && draws === 0) return null;
+  const drawPart = draws > 0 ? `${draws}分け` : "";
+  const wr = computeWinRate(record);
+  return `${wins}勝${losses}敗${drawPart}\n${wr.toFixed(1)}%`;
+}
+
+export default async function CompatibilityPage({ searchParams }: { searchParams?: Promise<SearchParams> }) {
+  const session = await getCurrentSession();
+  const params = await (searchParams as Promise<SearchParams> | undefined);
+
+  const { filter, start, end, tournamentId } = resolveFilterParams({
+    filterRaw: params?.filter,
+    modeRaw: params?.mode,
+    startRaw: params?.start,
+    endRaw: params?.end,
+    tournamentIdRaw: params?.tournamentId,
+  });
+
+  const [tournaments, { dates: availableDates, error: datesError }, { result, error }] =
+    await Promise.all([
+      fetchTournamentOptions(),
+      fetchMatchDates({ tournamentId }),
+      fetchCompatibilityMatrix(start, end, { tournamentId }),
+    ]);
+
+  const players = result?.players ?? [];
+  const matrix = result?.matrix;
+
+  return (
+    <main className="mx-auto min-h-screen w-full px-4 py-10">
+      <Suspense>
+        <FlashMessage />
+      </Suspense>
+      <div className="mx-auto max-w-screen-2xl space-y-6">
+        <AppHeader
+          current="compatibility"
+          sessionUser={session ? { displayName: session.displayName, role: session.role } : undefined}
+        />
+
+        <div className="rounded-xl border border-white/70 bg-white/90 shadow-xl backdrop-blur">
+          <div className="border-b border-emerald-100 px-4 py-4 sm:px-6">
+            <h1 className="text-xl font-bold text-emerald-900">相性表</h1>
+            <p className="mt-1 text-xs text-emerald-700/70">
+              行プレーヤーから見た対戦戦績を表示します。勝率 = 勝数 ÷ (勝数 + 敗数) × 100
+            </p>
+          </div>
+
+          <div className="p-4">
+            <div className="flex items-end gap-4">
+              <div className="flex-1">
+                <DateRangeFilter
+                  initialFilter={filter}
+                  initialStart={start}
+                  initialEnd={end}
+                  initialTournamentId={tournamentId ? String(tournamentId) : undefined}
+                  showMinGames={false}
+                  actionPath="/compatibility"
+                  availableDates={datesError ? undefined : availableDates}
+                  tournaments={tournaments}
+                />
+              </div>
+            </div>
+          </div>
+
+          <div className="px-4 pb-6">
+            {error ? (
+              <p className="text-sm text-red-600">{error}</p>
+            ) : players.length === 0 ? (
+              <p className="text-sm text-emerald-700/70">該当期間のデータがありません。</p>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="min-w-full border-collapse text-xs sm:text-sm">
+                  <thead>
+                    <tr>
+                      <th className="border border-emerald-200 bg-emerald-50 px-3 py-2 text-center font-semibold text-emerald-900 whitespace-nowrap">
+                        ↓行 vs 列→
+                      </th>
+                      {players.map((col) => (
+                        <th
+                          key={col}
+                          className="border border-emerald-200 bg-emerald-50 px-3 py-2 text-center font-semibold text-emerald-900 whitespace-nowrap"
+                        >
+                          {col}
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {players.map((row) => (
+                      <tr key={row}>
+                        <th className="border border-emerald-200 bg-emerald-50 px-3 py-2 text-center font-semibold text-emerald-900 whitespace-nowrap">
+                          {row}
+                        </th>
+                        {players.map((col) => {
+                          if (row === col) {
+                            return (
+                              <td
+                                key={col}
+                                className="border border-emerald-200 bg-emerald-50/50 px-3 py-2 text-center text-emerald-400"
+                              >
+                                -
+                              </td>
+                            );
+                          }
+                          const record = matrix?.get(row)?.get(col);
+                          const cellText = renderCellText(record);
+                          if (!cellText) {
+                            return (
+                              <td
+                                key={col}
+                                className="border border-emerald-200 px-3 py-2 text-center text-emerald-400"
+                              >
+                                -
+                              </td>
+                            );
+                          }
+                          const [wld, wr] = cellText.split("\n");
+                          return (
+                            <td
+                              key={col}
+                              className="border border-emerald-200 px-3 py-2 text-center"
+                            >
+                              <div className="whitespace-nowrap font-medium text-emerald-900">{wld}</div>
+                              <div className="whitespace-nowrap text-emerald-600">{wr}</div>
+                            </td>
+                          );
+                        })}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/components/app-header.tsx
+++ b/components/app-header.tsx
@@ -8,7 +8,7 @@ import { logoutAction } from "@/app/login/actions";
 import { Button, buttonVariants } from "@/components/ui/button";
 import type { RoleCode } from "@/lib/auth";
 
-type NavTarget = "input" | "matches" | "stats" | "admin";
+type NavTarget = "input" | "matches" | "stats" | "compatibility" | "admin";
 
 type AppHeaderProps = {
   current: NavTarget;
@@ -118,6 +118,9 @@ export function AppHeader({ current, sessionUser }: AppHeaderProps) {
         </Link>
         <Link href="/stats" className={navClass("stats")} onClick={handleNavClick("stats")} aria-busy={navigatingTo === "stats"} aria-disabled={navigatingTo === "stats"}>
           成績集計
+        </Link>
+        <Link href="/compatibility" className={navClass("compatibility")} onClick={handleNavClick("compatibility")} aria-busy={navigatingTo === "compatibility"} aria-disabled={navigatingTo === "compatibility"}>
+          相性表
         </Link>
 
         {showIndicator && (

--- a/lib/compatibility-matrix.d.ts
+++ b/lib/compatibility-matrix.d.ts
@@ -1,0 +1,15 @@
+import type { MatchResult } from "./matches";
+
+export type MatchupRecord = {
+  wins: number;
+  losses: number;
+  draws: number;
+};
+
+export type CompatibilityResult = {
+  players: string[];
+  matrix: Map<string, Map<string, MatchupRecord>>;
+};
+
+export declare function computeWinRate(record: MatchupRecord): number;
+export declare function buildCompatibilityMatrix(matches: MatchResult[]): CompatibilityResult;

--- a/lib/compatibility-matrix.js
+++ b/lib/compatibility-matrix.js
@@ -1,0 +1,80 @@
+// Pure computation for compatibility (head-to-head) matrix
+// Used by lib/compatibility.ts and unit tests
+
+/**
+ * @typedef {{ wins: number; losses: number; draws: number }} MatchupRecord
+ * @typedef {{ players: string[]; matrix: Map<string, Map<string, MatchupRecord>> }} CompatibilityResult
+ */
+
+/**
+ * 勝率を計算する。wins + losses = 0 の場合は 0 を返す。
+ * @param {MatchupRecord} record
+ * @returns {number}
+ */
+export function computeWinRate(record) {
+  const total = record.wins + record.losses;
+  return total === 0 ? 0 : (record.wins / total) * 100;
+}
+
+/**
+ * @param {Map<string, Map<string, MatchupRecord>>} matrix
+ * @param {string} rowPlayer
+ * @param {string} colPlayer
+ * @returns {MatchupRecord}
+ */
+function getOrCreateRecord(matrix, rowPlayer, colPlayer) {
+  if (!matrix.has(rowPlayer)) {
+    matrix.set(rowPlayer, new Map());
+  }
+  const row = matrix.get(rowPlayer);
+  if (!row.has(colPlayer)) {
+    row.set(colPlayer, { wins: 0, losses: 0, draws: 0 });
+  }
+  return row.get(colPlayer);
+}
+
+/**
+ * MatchResult[] からプレーヤー間の勝敗マトリクスを構築する。
+ * rank が 0 または name が空のエントリはスキップする。
+ *
+ * @param {Array<{ players: Array<{ name: string; rank: number }> }>} matches
+ * @returns {CompatibilityResult}
+ */
+export function buildCompatibilityMatrix(matches) {
+  /** @type {Map<string, Map<string, MatchupRecord>>} */
+  const matrix = new Map();
+  const playerSet = new Set();
+
+  for (const match of matches) {
+    // 有効なプレーヤーのみ（name と rank が有効な正の整数）
+    const validPlayers = match.players.filter((p) => p.name && p.rank > 0);
+
+    for (let i = 0; i < validPlayers.length; i++) {
+      for (let j = i + 1; j < validPlayers.length; j++) {
+        const a = validPlayers[i];
+        const b = validPlayers[j];
+
+        playerSet.add(a.name);
+        playerSet.add(b.name);
+
+        if (a.rank < b.rank) {
+          // a が上位 → a 勝ち、b 負け
+          getOrCreateRecord(matrix, a.name, b.name).wins += 1;
+          getOrCreateRecord(matrix, b.name, a.name).losses += 1;
+        } else if (a.rank > b.rank) {
+          // b が上位 → b 勝ち、a 負け
+          getOrCreateRecord(matrix, b.name, a.name).wins += 1;
+          getOrCreateRecord(matrix, a.name, b.name).losses += 1;
+        } else {
+          // 同着順 → 分け
+          getOrCreateRecord(matrix, a.name, b.name).draws += 1;
+          getOrCreateRecord(matrix, b.name, a.name).draws += 1;
+        }
+      }
+    }
+  }
+
+  const players = Array.from(playerSet).sort((a, b) => a.localeCompare(b, "ja"));
+
+  return { players, matrix };
+}

--- a/lib/compatibility.ts
+++ b/lib/compatibility.ts
@@ -1,0 +1,32 @@
+import type { MatchQueryOptions } from "./matches";
+import { fetchMatchResults } from "./matches";
+import { buildCompatibilityMatrix, computeWinRate } from "./compatibility-matrix.js";
+
+export type MatchupRecord = {
+  wins: number;
+  losses: number;
+  draws: number;
+};
+
+export type CompatibilityResult = {
+  /** ソート済み全プレーヤーリスト */
+  players: string[];
+  /** matrix[rowPlayer][colPlayer] = MatchupRecord（行プレーヤーから見た戦績）*/
+  matrix: Map<string, Map<string, MatchupRecord>>;
+};
+
+export { buildCompatibilityMatrix, computeWinRate };
+
+/** Supabase からゲームデータを取得し、相性マトリクスを算出する */
+export async function fetchCompatibilityMatrix(
+  startDate?: string,
+  endDate?: string,
+  options: MatchQueryOptions = {},
+): Promise<{ result: CompatibilityResult | null; error: string | null }> {
+  const { matches, error } = await fetchMatchResults(startDate, endDate, options);
+  if (error) {
+    return { result: null, error };
+  }
+  const result = buildCompatibilityMatrix(matches);
+  return { result, error: null };
+}

--- a/test/compatibility.test.js
+++ b/test/compatibility.test.js
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { buildCompatibilityMatrix, computeWinRate } from "../lib/compatibility-matrix.js";
+
+describe("computeWinRate", () => {
+  it("wins + losses > 0 のとき正しい勝率を返す", () => {
+    assert.strictEqual(computeWinRate({ wins: 2, losses: 1, draws: 0 }), (2 / 3) * 100);
+  });
+
+  it("全勝のとき 100 を返す", () => {
+    assert.strictEqual(computeWinRate({ wins: 3, losses: 0, draws: 0 }), 100);
+  });
+
+  it("全敗のとき 0 を返す", () => {
+    assert.strictEqual(computeWinRate({ wins: 0, losses: 3, draws: 0 }), 0);
+  });
+
+  it("0除算回避: wins + losses = 0 のとき 0 を返す", () => {
+    assert.strictEqual(computeWinRate({ wins: 0, losses: 0, draws: 5 }), 0);
+    assert.strictEqual(computeWinRate({ wins: 0, losses: 0, draws: 0 }), 0);
+  });
+});
+
+describe("buildCompatibilityMatrix", () => {
+  it("空の matches → 空のマトリクス・プレーヤーなし", () => {
+    const result = buildCompatibilityMatrix([]);
+    assert.deepStrictEqual(result.players, []);
+    assert.strictEqual(result.matrix.size, 0);
+  });
+
+  it("2人ゲーム: A(rank1) vs B(rank2) → A勝ち・B負け", () => {
+    const matches = [
+      {
+        players: [
+          { name: "A", rank: 1 },
+          { name: "B", rank: 2 },
+        ],
+      },
+    ];
+    const { matrix } = buildCompatibilityMatrix(matches);
+    const ab = matrix.get("A")?.get("B");
+    const ba = matrix.get("B")?.get("A");
+    assert.deepStrictEqual(ab, { wins: 1, losses: 0, draws: 0 });
+    assert.deepStrictEqual(ba, { wins: 0, losses: 1, draws: 0 });
+  });
+
+  it("同着順 → 分けカウント増加", () => {
+    const matches = [
+      {
+        players: [
+          { name: "A", rank: 1 },
+          { name: "B", rank: 1 },
+        ],
+      },
+    ];
+    const { matrix } = buildCompatibilityMatrix(matches);
+    const ab = matrix.get("A")?.get("B");
+    const ba = matrix.get("B")?.get("A");
+    assert.deepStrictEqual(ab, { wins: 0, losses: 0, draws: 1 });
+    assert.deepStrictEqual(ba, { wins: 0, losses: 0, draws: 1 });
+  });
+
+  it("4人ゲーム: 全ペア組み合わせが正しく集計される", () => {
+    // A=1位, B=2位, C=3位, D=4位
+    const matches = [
+      {
+        players: [
+          { name: "A", rank: 1 },
+          { name: "B", rank: 2 },
+          { name: "C", rank: 3 },
+          { name: "D", rank: 4 },
+        ],
+      },
+    ];
+    const { matrix } = buildCompatibilityMatrix(matches);
+
+    // A vs B: A 勝ち
+    assert.strictEqual(matrix.get("A")?.get("B")?.wins, 1);
+    assert.strictEqual(matrix.get("B")?.get("A")?.losses, 1);
+
+    // A vs D: A 勝ち
+    assert.strictEqual(matrix.get("A")?.get("D")?.wins, 1);
+
+    // C vs D: C 勝ち
+    assert.strictEqual(matrix.get("C")?.get("D")?.wins, 1);
+    assert.strictEqual(matrix.get("D")?.get("C")?.losses, 1);
+  });
+
+  it("rank が 0 のプレーヤーはスキップされる", () => {
+    const matches = [
+      {
+        players: [
+          { name: "A", rank: 1 },
+          { name: "B", rank: 0 }, // 無効
+        ],
+      },
+    ];
+    const { players, matrix } = buildCompatibilityMatrix(matches);
+    // ペアが成立しないため何も記録されない
+    assert.deepStrictEqual(players, []);
+    assert.strictEqual(matrix.size, 0);
+  });
+
+  it("name が空のプレーヤーはスキップされる", () => {
+    const matches = [
+      {
+        players: [
+          { name: "", rank: 1 },
+          { name: "B", rank: 2 },
+        ],
+      },
+    ];
+    const { players } = buildCompatibilityMatrix(matches);
+    assert.deepStrictEqual(players, []);
+  });
+
+  it("複数ゲームにわたって戦績が累積される", () => {
+    const matches = [
+      { players: [{ name: "A", rank: 1 }, { name: "B", rank: 2 }] },
+      { players: [{ name: "A", rank: 2 }, { name: "B", rank: 1 }] },
+      { players: [{ name: "A", rank: 1 }, { name: "B", rank: 2 }] },
+    ];
+    const { matrix } = buildCompatibilityMatrix(matches);
+    const ab = matrix.get("A")?.get("B");
+    assert.deepStrictEqual(ab, { wins: 2, losses: 1, draws: 0 });
+  });
+
+  it("プレーヤーリストが日本語ロケールでソートされる", () => {
+    const matches = [
+      {
+        players: [
+          { name: "鈴木", rank: 1 },
+          { name: "田中", rank: 2 },
+          { name: "佐藤", rank: 3 },
+        ],
+      },
+    ];
+    const { players } = buildCompatibilityMatrix(matches);
+    const expected = ["佐藤", "鈴木", "田中"].sort((a, b) => a.localeCompare(b, "ja"));
+    assert.deepStrictEqual(players, expected);
+  });
+});


### PR DESCRIPTION
## 設計概要
- プレーヤー間の対戦戦績（勝・負・分け・勝率）を N×N マトリクスで閲覧できる新規ページ `/compatibility` を追加
- Spec Kit: `.specify/specs/121-compatibility-matrix/spec.md` / `plan.md` / `tasks.md`
- 勝率計算: 勝数 ÷ (勝数 + 敗数) × 100（0除算は 0%）
- 既存の `fetchMatchResults` / `DateRangeFilter` / `resolveFilterParams` を再利用

## 実装概要
| ファイル | 種別 | 内容 |
|---|---|---|
| `lib/compatibility-matrix.js` | 新規 | 勝敗集計の純粋計算ロジック（テスト対象） |
| `lib/compatibility-matrix.d.ts` | 新規 | 型定義 |
| `lib/compatibility.ts` | 新規 | Supabase fetchラッパー |
| `app/compatibility/page.tsx` | 新規 | 相性表ページ（Server Component） |
| `components/app-header.tsx` | 変更 | NavTarget型に `compatibility` 追加、ナビリンク追加 |
| `test/compatibility.test.js` | 新規 | ユニットテスト 12件 |

## 実行した検証コマンドと結果
- `npm run build`: 成功（`/compatibility` ルートが追加されたことを確認）
- `npm run lint`: 警告は既存コードのみ（今回変更ファイルに新規 warning なし）
- `npm run test:unit`: 31/31 通過（うち新規 12件）

## 手動動作確認の内容
- ビルド成果物に `/compatibility` ルートが含まれることをビルドログで確認
- 未ログインアクセス: 既存ミドルウェアが全ルートを認証済み必須にしているため保護済み（middleware.ts の動作は既存テストで確認済み）
- 注: Supabase 接続を要する実ブラウザ確認はローカル環境依存のため未実施

## 既知の未解決事項
- なし

## Worklog
- `.worklog/logs/2026-05-08.md` に記録済み（`.gitignore` 対象のためコミットには未含）

## 関連 Issue
- Closes #121