### PR TITLE
release: develop -> main (Issue #121 相性表 minGamesフィルター追加)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -39,6 +39,7 @@
 * **設計レビューと停止:** 設計資料を作成した後、エージェント自身が整合性・抜け漏れ・リスクを自己レビューし、その結果をユーザーへ提示して確認を求めること。自己レビューには `worklog` の作成確認を含めること。ユーザーの承認なしに実装フェーズへ進んではならない。
 * **設計承認後の委任:** ユーザーが設計を承認し実装を依頼した場合、実装・テスト・動作確認・コミット・push・PR作成は追加確認なしで完遂してよい。破壊的変更・高リスク変更・要件矛盾が新たに発覚した場合は例外として停止する。
 * **worklog 起票タイミング:** 実装フェーズ開始時点で当日 `worklog` を必ず起票すること（例: `npm run worklog:start -- --summary "Issue #<番号> 実装開始" --reason "..." --tags "issue-<番号>,implementation,worklog"`）。当日の実装作業完了までに、該当エントリが `.worklog/logs/YYYY-MM-DD.md` に存在していることを必須とする。
+* **worklog 完了記録:** develop→main PR 作成後（エージェント責務の末尾）には、`done_when` に「main マージ後に `npm run worklog:done` を実行」と明記すること。`main` ブランチで `git pull` / `git merge` を実行すると `.husky/post-merge` フックが自動で `worklog:done` エントリを追記する。手動で記録したい場合は `npm run worklog:done -- --summary "<完了内容>" --tags "main,merge,issue-<番号>"` を実行すること。
 * **品質管理:** * コミット前に `npm run build` を実行し、失敗時はコミットしない。
     * 可能な場合は `npm run lint` と `npm test` も実行し、結果をPR本文に記載する。
     * 修正を行うたびに `npm run build` を実行し、エラーがある場合は対応してから次の作業へ進むことを忘れない。

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,0 +1,9 @@
+#!/bin/sh
+# post-merge: main ブランチへのマージ完了時に worklog done エントリを自動追記する
+BRANCH=$(git branch --show-current)
+if [ "$BRANCH" = "main" ]; then
+  LAST_MERGE_MSG=$(git log --merges --oneline -1 2>/dev/null || echo "")
+  node scripts/worklog.mjs done \
+    --summary "main へのマージ完了: ${LAST_MERGE_MSG}" \
+    --tags "main,merge"
+fi

--- a/.specify/specs/121-compatibility-matrix/plan.md
+++ b/.specify/specs/121-compatibility-matrix/plan.md
@@ -69,9 +69,20 @@ export async function fetchCompatibilityMatrix(
 `app/stats/page.tsx` に倣った Server Component として実装する。
 
 - `getCurrentSession()` でセッション取得（ミドルウェアが認証を保証済みだが、ヘッダー表示に必要）
-- `resolveFilterParams()` でクエリパラメータを解析（`minGames` は使用しない）
-- `fetchCompatibilityMatrix()` でデータ取得
-- `DateRangeFilter` に `showMinGames={false}` を渡す（`/matches` と同様の方法）
+- `resolveFilterParams()` でクエリパラメータを解析（`minGamesRaw` を含む）
+- `effectiveMinGames` の計算（stats ページと同じロジック）:
+  ```typescript
+  const initialMinGamesRaw = Array.isArray(params?.minGames) ? params?.minGames[0] : params?.minGames;
+  const hasMinGamesParam = initialMinGamesRaw !== undefined;
+  const { filter, start, end, minGames, tournamentId } = resolveFilterParams({
+    minGamesRaw: params?.minGames,
+    // ... その他パラメータ
+  });
+  const effectiveMinGames = typeof minGames === "number" ? minGames
+    : !hasMinGamesParam && filter === "year" ? 20 : undefined;
+  ```
+- `fetchCompatibilityMatrix()` でデータ取得（`{ minGames: effectiveMinGames }` を options に渡す）
+- `DateRangeFilter` に `showMinGames={true}` を渡す（`initialMinGames={String(effectiveMinGames ?? "")}` も設定）
 - マトリクステーブルを JSX で描画（Server Component 内でインライン実装）
 - 各行プレーヤーごとに対戦相手セルの勝率を算出し、上位3位まで背景色を適用
   - 色は `lib/stats-rank-theme.ts` の `RANK_ROW_BG`（1位/2位/3位）を再利用
@@ -118,8 +129,8 @@ components/
 | コンポーネント/関数 | 再利用方法 |
 |---|---|
 | `fetchMatchResults` | そのまま呼び出し。フィルタ（日付・トーナメント）を渡す |
-| `resolveFilterParams` | そのまま呼び出し。`minGamesRaw` は渡さない |
-| `DateRangeFilter` | `showMinGames={false}` で呼び出し |
+| `resolveFilterParams` | `minGamesRaw: params?.minGames` を含めて呼び出す |
+| `DateRangeFilter` | `showMinGames={true}` / `initialMinGames` で呼び出す |
 | `fetchMatchDates` | availableDates 取得に使用 |
 | `fetchTournamentOptions` | トーナメント一覧取得に使用 |
 | `getCurrentSession` | セッション取得に使用 |
@@ -159,7 +170,8 @@ function buildTopWinRateRanksByRow(
 2. 同着順 → 分け1
 3. 空の matches → 空のマトリクス
 4. 0除算回避（wins + losses = 0）→ 勝率 0%
-
+5. minGames フィルタリング: 2試合以上を選択した場合に参加ゲーム数が 1 のプレーヤーが除外されることを検証
+6. minGames = 0 または undefined の場合: 全プレーヤーが返ることを検証（「条件なし」選択時に相当）
 ---
 
 ## リスク・注意事項

--- a/.specify/specs/121-compatibility-matrix/spec.md
+++ b/.specify/specs/121-compatibility-matrix/spec.md
@@ -40,6 +40,8 @@
 
 1. **Given** 相性表が表示されている、**When** DateRangeFilter で "2026年" を選択、**Then** 2026年内のゲームのみを対象とした戦績が再表示される
 2. **Given** 特定トーナメントを選択、**When** 相性表を表示、**Then** そのトーナメントの試合のみを集計した戦績が表示される
+3. **Given** 最低試合数に「20試合以上」を選択、**When** 相性表を表示、**Then** 期間内に 20 試合未満のプレーヤーは行・列ともに除外される
+4. **Given** 年次フィルタを選択しかつ最低試合数を変更していない、**When** 相性表を表示、**Then** デフォルト「20試合以上」が適用され 20 試合未満のプレーヤーが除外される（成績集計と同じ挙動）
 
 ---
 
@@ -63,6 +65,7 @@
 - 勝数・敗数が両方0（分けのみ）→ 勝率 0%
 - wins + losses = 0 の場合（分けのみ）→ 0除算回避: 勝率 0%
 - 3位以内の境界で同率が発生した場合 → 同順位として同じ色を適用（順位バッジは表示しない）
+- minGames 指定時に全プレーヤーが閾値未満になった場合 → 「データがありません」メッセージを表示
 
 ---
 
@@ -84,6 +87,8 @@
 | F-10 | admin / editor / viewer 全ロールが閲覧可能 |
 | F-11 | 各行プレーヤー視点で、対戦相手の勝率上位3位について勝率文字の背景色を付与する |
 | F-12 | 上位判定は勝率（小数1位）降順で行い、同率は同順位として同じ背景色を適用する |
+| F-13 | 最低試合数フィルタを提供する。UI は `DateRangeFilter` 内の 2 択セレクト（「試合数：20試合以上」/「試合数：条件なし」）で、20試合以上を選択した場合に 20 試合未満のプレーヤーを行・列から除外する |
+| F-14 | 年次フィルタ選択時の最低試合数デフォルトは「試合数：20試合以上」（成績集計と同一）。カスタム期間フィルタ時は「試合数：条件なし」がデフォルト。全期間フィルタ時はセレクト自体が非表示（条件なし固定）|
 
 ### 非機能要件
 
@@ -92,6 +97,7 @@
 | N-01 | モバイル・デスクトップともにスクロール対応（テーブルは `overflow-x-auto` でラップ）|
 | N-02 | 既存の Tailwind / コンポーネントスタイルに準拠 |
 | N-03 | Server Component + Server Action パターン（stats ページと同様）|
+| N-04 | minGames フィルタの挙動は `app/stats/page.tsx` と同一にし、URLパラメータ `minGames` で受け取る |
 
 ---
 
@@ -146,9 +152,9 @@ type CompatibilityMatrix = Map<string, Map<string, MatchupRecord>>;
 | ファイル | 種別 | 概要 |
 |---|---|---|
 | `app/compatibility/page.tsx` | 新規 | 相性表ページ（Server Component） |
-| `lib/compatibility.ts` | 新規 | 相性データ算出ロジック |
+| `lib/compatibility.ts` | 変更 | `fetchCompatibilityMatrix` の `options` に `minGames` を追加 |
+| `lib/compatibility-matrix.js` | 変更 | `buildCompatibilityMatrix` にプレーヤーゲーム数カウント機能を追加（または `fetchCompatibilityMatrix` でポストプロセス）|
 | `components/app-header.tsx` | 変更 | NavTarget に "compatibility" 追加、ナビリンク追加 |
-| `lib/authorization.ts` または型定義 | 変更 | NavTarget 型へ "compatibility" を追加（必要な場合） |
 
 ---
 

--- a/.specify/specs/121-compatibility-matrix/tasks.md
+++ b/.specify/specs/121-compatibility-matrix/tasks.md
@@ -35,6 +35,11 @@
   - `buildCompatibilityMatrix(matches: MatchResult[]): CompatibilityResult` — インメモリ集計（export してテスト対象にする）
   - `fetchCompatibilityMatrix(startDate?, endDate?, options): Promise<...>` — fetchMatchResults を呼び出し、buildCompatibilityMatrix に渡す
 
+- [ ] **T-11** `fetchCompatibilityMatrix` に minGames フィルタリングを追加
+  - `options: { tournamentId?: number; minGames?: number }` に拡張
+  - `buildCompatibilityMatrix` 実行後、各プレーヤーのゲーム数を `matches` から直接カウント
+  - `minGames` 閾値未満のプレーヤーを `players` リストと `matrix` から除外（ポストプロセス）
+
 ---
 
 ## Phase 2: ユニットテスト
@@ -46,6 +51,10 @@
   - wins+losses=0 → 勝率 0%
   - プレーヤー名 trim の確認
 
+- [ ] **T-21** minGames フィルタリングのユニットテストを追加
+  - minGames = 20: 1試合のみのプレーヤーが除外されることを検証
+  - minGames = 0 または undefined: 全プレーヤーが返ることを検証（「条件なし」選択時相当）
+
 ---
 
 ## Phase 3: ページ実装
@@ -54,10 +63,11 @@
   - metadata（タイトル: "相性表 | 麻雀成績入力"）
   - `export const dynamic = "force-dynamic"`
   - `getCurrentSession()` でセッション取得
-  - `resolveFilterParams()` でクエリパラメータ解析（minGames なし）
+  - `resolveFilterParams()` でクエリパラメータ解析（`minGamesRaw` を含む）
+  - `effectiveMinGames` の計算（stats ページと同じロジック: year フィルタ時デフォルト 20）
   - `fetchTournamentOptions()`, `fetchMatchDates()`, `fetchCompatibilityMatrix()` を並列呼び出し（Promise.all）
   - `AppHeader current="compatibility"` を設置
-  - `DateRangeFilter` を `showMinGames={false}` で設置、`actionPath="/compatibility"`
+  - `DateRangeFilter` を `showMinGames={true}` / `initialMinGames` で設置、`actionPath="/compatibility"`
   - マトリクステーブルを JSX で描画
     - `overflow-x-auto` ラップ
     - ヘッダー行・列にプレーヤー名
@@ -70,6 +80,12 @@
   - 同率は同順位（同じ背景色）
   - 色は `lib/stats-rank-theme.ts` の `RANK_ROW_BG` を再利用
   - 順位バッジは表示しない
+
+- [ ] **T-32** minGames フィルターのページ側実装（T-11 に対応）
+  - `resolveFilterParams` に `minGamesRaw: params?.minGames` を渡す
+  - `effectiveMinGames` を計算（year フィルタ時のデフォルト 20 を含む）
+  - `fetchCompatibilityMatrix` に `{ minGames: effectiveMinGames }` を渡す
+  - `DateRangeFilter` を `showMinGames={true}` に変更し `initialMinGames` を渡す
 
 ---
 

--- a/app/compatibility/page.tsx
+++ b/app/compatibility/page.tsx
@@ -71,19 +71,28 @@ export default async function CompatibilityPage({ searchParams }: { searchParams
   const session = await getCurrentSession();
   const params = await (searchParams as Promise<SearchParams> | undefined);
 
-  const { filter, start, end, tournamentId } = resolveFilterParams({
+  const initialMinGamesRaw = Array.isArray(params?.minGames) ? params?.minGames[0] : params?.minGames;
+  const hasMinGamesParam = initialMinGamesRaw !== undefined;
+
+  const { filter, start, end, minGames, tournamentId } = resolveFilterParams({
     filterRaw: params?.filter,
     modeRaw: params?.mode,
     startRaw: params?.start,
     endRaw: params?.end,
+    minGamesRaw: params?.minGames,
     tournamentIdRaw: params?.tournamentId,
   });
+
+  const effectiveMinGames =
+    typeof minGames === "number" ? minGames
+    : !hasMinGamesParam && filter === "year" ? 20
+    : undefined;
 
   const [tournaments, { dates: availableDates, error: datesError }, { result, error }] =
     await Promise.all([
       fetchTournamentOptions(),
       fetchMatchDates({ tournamentId }),
-      fetchCompatibilityMatrix(start, end, { tournamentId }),
+      fetchCompatibilityMatrix(start, end, { tournamentId, minGames: effectiveMinGames }),
     ]);
 
   const players = result?.players ?? [];
@@ -120,7 +129,8 @@ export default async function CompatibilityPage({ searchParams }: { searchParams
                   initialStart={start}
                   initialEnd={end}
                   initialTournamentId={tournamentId ? String(tournamentId) : undefined}
-                  showMinGames={false}
+                  initialMinGames={effectiveMinGames !== undefined ? String(effectiveMinGames) : undefined}
+                  showMinGames={true}
                   actionPath="/compatibility"
                   availableDates={datesError ? undefined : availableDates}
                   tournaments={tournaments}

--- a/lib/compatibility-matrix.d.ts
+++ b/lib/compatibility-matrix.d.ts
@@ -13,3 +13,8 @@ export type CompatibilityResult = {
 
 export declare function computeWinRate(record: MatchupRecord): number;
 export declare function buildCompatibilityMatrix(matches: MatchResult[]): CompatibilityResult;
+export declare function filterCompatibilityByMinGames(
+  result: CompatibilityResult,
+  matches: MatchResult[],
+  minGames: number,
+): CompatibilityResult;

--- a/lib/compatibility-matrix.js
+++ b/lib/compatibility-matrix.js
@@ -78,3 +78,33 @@ export function buildCompatibilityMatrix(matches) {
 
   return { players, matrix };
 }
+
+/**
+ * buildCompatibilityMatrix の結果から minGames 未満の参加数プレーヤーを除外する。
+ * matches は buildCompatibilityMatrix に渡したものと同一のデータを使用する。
+ *
+ * @param {{ players: string[]; matrix: Map<string, Map<string, MatchupRecord>> }} result
+ * @param {Array<{ players: Array<{ name: string; rank: number }> }>} matches
+ * @param {number} minGames
+ * @returns {{ players: string[]; matrix: Map<string, Map<string, MatchupRecord>> }}
+ */
+export function filterCompatibilityByMinGames(result, matches, minGames) {
+  const gameCountMap = new Map();
+  for (const match of matches) {
+    for (const player of match.players) {
+      if (player.name && player.rank > 0) {
+        gameCountMap.set(player.name, (gameCountMap.get(player.name) ?? 0) + 1);
+      }
+    }
+  }
+  const eligible = result.players.filter((p) => (gameCountMap.get(p) ?? 0) >= minGames);
+  const filteredMatrix = new Map(
+    eligible.map((p) => [
+      p,
+      new Map(
+        eligible.map((q) => [q, result.matrix.get(p)?.get(q) ?? { wins: 0, losses: 0, draws: 0 }]),
+      ),
+    ]),
+  );
+  return { players: eligible, matrix: filteredMatrix };
+}

--- a/lib/compatibility.ts
+++ b/lib/compatibility.ts
@@ -1,4 +1,4 @@
-import { buildCompatibilityMatrix, computeWinRate } from "./compatibility-matrix.js";
+import { buildCompatibilityMatrix, computeWinRate, filterCompatibilityByMinGames } from "./compatibility-matrix.js";
 import type { MatchQueryOptions } from "./matches";
 import { fetchMatchResults } from "./matches";
 
@@ -17,16 +17,25 @@ export type CompatibilityResult = {
 
 export { buildCompatibilityMatrix, computeWinRate };
 
+type CompatibilityOptions = MatchQueryOptions & { minGames?: number };
+
 /** Supabase からゲームデータを取得し、相性マトリクスを算出する */
 export async function fetchCompatibilityMatrix(
   startDate?: string,
   endDate?: string,
-  options: MatchQueryOptions = {},
+  options: CompatibilityOptions = {},
 ): Promise<{ result: CompatibilityResult | null; error: string | null }> {
-  const { matches, error } = await fetchMatchResults(startDate, endDate, options);
+  const { minGames, ...matchOptions } = options;
+  const { matches, error } = await fetchMatchResults(startDate, endDate, matchOptions);
   if (error) {
     return { result: null, error };
   }
-  const result = buildCompatibilityMatrix(matches);
-  return { result, error: null };
+  const raw = buildCompatibilityMatrix(matches);
+
+  if (minGames && minGames > 0) {
+    const filtered = filterCompatibilityByMinGames(raw, matches, minGames);
+    return { result: filtered, error: null };
+  }
+
+  return { result: raw, error: null };
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "worklog:start": "node scripts/worklog.mjs start",
     "worklog:review": "node scripts/worklog.mjs review",
     "worklog:generate": "node scripts/worklog.mjs start",
+    "worklog:done": "node scripts/worklog.mjs done",
     "worklog:summary": "node scripts/summary-worklog.mjs"
   },
   "dependencies": {

--- a/scripts/worklog.mjs
+++ b/scripts/worklog.mjs
@@ -217,10 +217,57 @@ function extractLines(content, prefix) {
 
 // `generateReview` removed. Delegate `review` command to `scripts/summary-worklog.mjs`.
 
+function appendDoneEntry(args) {
+  ensureDir(LOG_DIR);
+
+  const current = now();
+  const day = fmtDate(current);
+  const filePath = path.join(LOG_DIR, `${day}.md`);
+  const tags = args.tags.length ? args.tags.join(", ") : "main,merge";
+  const summary = args.summary || "(完了内容を要約してください)";
+
+  // 当日ログがなければ新規作成
+  if (!fs.existsSync(filePath)) {
+    const header = [
+      `# Worklog ${day}`,
+      "",
+      "このファイルは AI 作業記録の自動生成で作成されます。",
+      "機密情報（鍵・トークン・個人情報）は記録しないでください。",
+      "",
+      "## Entries",
+      "",
+    ].join("\n");
+    fs.writeFileSync(filePath, header, "utf8");
+  }
+
+  // 直近のマージコミットメッセージを取得
+  const lastMerge = runGit("git log --merges --oneline -1");
+
+  const entry = [
+    `### ${fmtDateTime(current)}`,
+    `- branch: ${getBranch()}`,
+    `- tags: ${tags}`,
+    `- summary: ${summary}`,
+    lastMerge ? `- merge_commit: ${lastMerge}` : "",
+    "- status: done",
+    "",
+  ]
+    .filter((line) => line !== "")
+    .join("\n") + "\n";
+
+  fs.appendFileSync(filePath, entry, "utf8");
+  console.log(`Worklog done entry appended: ${path.relative(ROOT, filePath)}`);
+}
+
 function main() {
   const args = parseArgs(process.argv.slice(2));
   if (args.command === "start" || args.command === "touch") {
     appendWorklog(args);
+    return;
+  }
+
+  if (args.command === "done") {
+    appendDoneEntry(args);
     return;
   }
 

--- a/test/compatibility.test.js
+++ b/test/compatibility.test.js
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { buildCompatibilityMatrix, computeWinRate } from "../lib/compatibility-matrix.js";
+import { buildCompatibilityMatrix, computeWinRate, filterCompatibilityByMinGames } from "../lib/compatibility-matrix.js";
 
 describe("computeWinRate", () => {
   it("wins + losses > 0 のとき正しい勝率を返す", () => {
@@ -139,5 +139,50 @@ describe("buildCompatibilityMatrix", () => {
     const { players } = buildCompatibilityMatrix(matches);
     const expected = ["佐藤", "鈴木", "田中"].sort((a, b) => a.localeCompare(b, "ja"));
     assert.deepStrictEqual(players, expected);
+  });
+});
+
+describe("filterCompatibilityByMinGames", () => {
+  const makeMatches = (playerGames) => {
+    // playerGames: { [name]: numberOfGames }
+    const matches = [];
+    for (const [name, count] of Object.entries(playerGames)) {
+      for (let i = 0; i < count; i++) {
+        matches.push({ players: [{ name, rank: 1 }, { name: "Dummy", rank: 2 }] });
+      }
+    }
+    return matches;
+  };
+
+  it("minGames = 20 のとき 1 試合のみのプレーヤーが除外される", () => {
+    const matches = makeMatches({ Alice: 20, Bob: 1 });
+    const raw = buildCompatibilityMatrix(matches);
+    const result = filterCompatibilityByMinGames(raw, matches, 20);
+    assert.ok(result.players.includes("Alice"));
+    assert.ok(!result.players.includes("Bob"));
+  });
+
+  it("全プレーヤーが閾値以上ならそのまま返る", () => {
+    const matches = makeMatches({ Alice: 20, Bob: 25 });
+    const raw = buildCompatibilityMatrix(matches);
+    const result = filterCompatibilityByMinGames(raw, matches, 20);
+    assert.ok(result.players.includes("Alice"));
+    assert.ok(result.players.includes("Bob"));
+  });
+
+  it("minGames = 0 を渡しても全プレーヤーが返る", () => {
+    const matches = makeMatches({ Alice: 1, Bob: 1 });
+    const raw = buildCompatibilityMatrix(matches);
+    const result = filterCompatibilityByMinGames(raw, matches, 0);
+    assert.ok(result.players.includes("Alice"));
+    assert.ok(result.players.includes("Bob"));
+  });
+
+  it("全プレーヤーが閾値未満のとき空のプレーヤーリストを返す", () => {
+    const matches = makeMatches({ Alice: 1, Bob: 1 });
+    const raw = buildCompatibilityMatrix(matches);
+    const result = filterCompatibilityByMinGames(raw, matches, 5);
+    assert.deepStrictEqual(result.players, []);
+    assert.strictEqual(result.matrix.size, 0);
   });
 });


### PR DESCRIPTION
## 概要

PR #233（feat: 相性表に最低試合数フィルター追加）および PR #235（chore: worklog:done コマンドと post-merge フック追加）を develop から main へ昇格する。

---

## 設計概要

### Issue #121 minGames フィルター
相性表（Issue #121）に成績集計と同様の最低試合数フィルター（minGames）を追加した。
フィルターは `DateRangeFilter` 内の 2 択セレクト（「試合数：20試合以上」/「試合数：条件なし」）で実装されており、年次フィルタ選択時はデフォルトで 20 試合以上が適用される。

Spec Kit: `.specify/specs/121-compatibility-matrix/spec.md` / `plan.md` / `tasks.md`

### worklog 運用改善
エージェントの責務（feature→develop PR 作成まで）を変えず、`main` ブランチへの `git pull` / `git merge` という既存の手順に worklog 更新を自然に組み込んだ。

---

## 実装概要

### Issue #121 minGames フィルター

| ファイル | 変更内容 |
|---|---|
| `lib/compatibility-matrix.js` | `filterCompatibilityByMinGames()` 純粋関数を追加 |
| `lib/compatibility-matrix.d.ts` | 型定義追加 |
| `lib/compatibility.ts` | `fetchCompatibilityMatrix` の options に `minGames?` を追加、ポストプロセスでプレーヤー除外 |
| `app/compatibility/page.tsx` | `resolveFilterParams` に `minGamesRaw` 追加、`effectiveMinGames` 計算（年次フィルタ時デフォルト 20）、`showMinGames={true}` に変更 |
| `test/compatibility.test.js` | `filterCompatibilityByMinGames` テスト 4 件追加（合計 16 件） |

### worklog 運用改善

| ファイル | 変更内容 |
|---|---|
| `scripts/worklog.mjs` | `done` コマンド追加（`appendDoneEntry` 関数） |
| `package.json` | `worklog:done` スクリプト追加 |
| `.husky/post-merge` | 新規作成。`main` ブランチでのマージ完了時に `worklog:done` を自動実行 |
| `.github/copilot-instructions.md` | worklog 完了記録ルールを明文化（post-merge フック説明追加） |

---

## 実行した検証コマンドと結果

- `npm run build`: 成功
- `npm test`: pass 35 / fail 0（compatibility テスト 16 件を含む）
- `npm run lint`: 既存警告 2 件のみ（今回変更に起因する新規エラーなし）
- `node scripts/worklog.mjs done --summary "テスト" --tags "test"`: エントリ追記を確認

---

## 手動動作確認の内容

ローカル環境では Supabase 接続を必要とするため、ビルド成功・テスト全通過をもって代替確認とする。

本番 / ステージング環境での確認ポイント:
- 年次フィルタ時、「試合数：20試合以上」がデフォルト選択されること
- 20 試合未満のプレーヤーが行・列から除外されること
- 「試合数：条件なし」選択時、全プレーヤーが表示されること
- 全期間フィルタ時、minGames セレクトが非表示になること

worklog 動作確認:
- `main` ブランチで `git pull` / `git merge` 実行時、`post-merge` フックが起動し当日ログに `status: done` エントリが追記される

---

## 既知の未解決事項

なし

---

## Worklog

- `.worklog/logs/2026-05-08.md` に記録済み
- **この PR のマージ後**: `post-merge` フックが自動で `worklog:done` エントリを追記する（新規追加機能の初回適用）

---

## 関連 Issue / PR

- Issue #121
- PR #233（feature/issue-121-mingames-filter → develop）
- PR #235（chore: worklog:done コマンド → develop）