### PR TITLE
chore: worklog:done コマンドと post-merge フックを追加

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -39,6 +39,7 @@
 * **設計レビューと停止:** 設計資料を作成した後、エージェント自身が整合性・抜け漏れ・リスクを自己レビューし、その結果をユーザーへ提示して確認を求めること。自己レビューには `worklog` の作成確認を含めること。ユーザーの承認なしに実装フェーズへ進んではならない。
 * **設計承認後の委任:** ユーザーが設計を承認し実装を依頼した場合、実装・テスト・動作確認・コミット・push・PR作成は追加確認なしで完遂してよい。破壊的変更・高リスク変更・要件矛盾が新たに発覚した場合は例外として停止する。
 * **worklog 起票タイミング:** 実装フェーズ開始時点で当日 `worklog` を必ず起票すること（例: `npm run worklog:start -- --summary "Issue #<番号> 実装開始" --reason "..." --tags "issue-<番号>,implementation,worklog"`）。当日の実装作業完了までに、該当エントリが `.worklog/logs/YYYY-MM-DD.md` に存在していることを必須とする。
+* **worklog 完了記録:** develop→main PR 作成後（エージェント責務の末尾）には、`done_when` に「main マージ後に `npm run worklog:done` を実行」と明記すること。`main` ブランチで `git pull` / `git merge` を実行すると `.husky/post-merge` フックが自動で `worklog:done` エントリを追記する。手動で記録したい場合は `npm run worklog:done -- --summary "<完了内容>" --tags "main,merge,issue-<番号>"` を実行すること。
 * **品質管理:** * コミット前に `npm run build` を実行し、失敗時はコミットしない。
     * 可能な場合は `npm run lint` と `npm test` も実行し、結果をPR本文に記載する。
     * 修正を行うたびに `npm run build` を実行し、エラーがある場合は対応してから次の作業へ進むことを忘れない。

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,0 +1,9 @@
+#!/bin/sh
+# post-merge: main ブランチへのマージ完了時に worklog done エントリを自動追記する
+BRANCH=$(git branch --show-current)
+if [ "$BRANCH" = "main" ]; then
+  LAST_MERGE_MSG=$(git log --merges --oneline -1 2>/dev/null || echo "")
+  node scripts/worklog.mjs done \
+    --summary "main へのマージ完了: ${LAST_MERGE_MSG}" \
+    --tags "main,merge"
+fi

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "worklog:start": "node scripts/worklog.mjs start",
     "worklog:review": "node scripts/worklog.mjs review",
     "worklog:generate": "node scripts/worklog.mjs start",
+    "worklog:done": "node scripts/worklog.mjs done",
     "worklog:summary": "node scripts/summary-worklog.mjs"
   },
   "dependencies": {

--- a/scripts/worklog.mjs
+++ b/scripts/worklog.mjs
@@ -217,10 +217,57 @@ function extractLines(content, prefix) {
 
 // `generateReview` removed. Delegate `review` command to `scripts/summary-worklog.mjs`.
 
+function appendDoneEntry(args) {
+  ensureDir(LOG_DIR);
+
+  const current = now();
+  const day = fmtDate(current);
+  const filePath = path.join(LOG_DIR, `${day}.md`);
+  const tags = args.tags.length ? args.tags.join(", ") : "main,merge";
+  const summary = args.summary || "(完了内容を要約してください)";
+
+  // 当日ログがなければ新規作成
+  if (!fs.existsSync(filePath)) {
+    const header = [
+      `# Worklog ${day}`,
+      "",
+      "このファイルは AI 作業記録の自動生成で作成されます。",
+      "機密情報（鍵・トークン・個人情報）は記録しないでください。",
+      "",
+      "## Entries",
+      "",
+    ].join("\n");
+    fs.writeFileSync(filePath, header, "utf8");
+  }
+
+  // 直近のマージコミットメッセージを取得
+  const lastMerge = runGit("git log --merges --oneline -1");
+
+  const entry = [
+    `### ${fmtDateTime(current)}`,
+    `- branch: ${getBranch()}`,
+    `- tags: ${tags}`,
+    `- summary: ${summary}`,
+    lastMerge ? `- merge_commit: ${lastMerge}` : "",
+    "- status: done",
+    "",
+  ]
+    .filter((line) => line !== "")
+    .join("\n") + "\n";
+
+  fs.appendFileSync(filePath, entry, "utf8");
+  console.log(`Worklog done entry appended: ${path.relative(ROOT, filePath)}`);
+}
+
 function main() {
   const args = parseArgs(process.argv.slice(2));
   if (args.command === "start" || args.command === "touch") {
     appendWorklog(args);
+    return;
+  }
+
+  if (args.command === "done") {
+    appendDoneEntry(args);
     return;
   }
 


### PR DESCRIPTION
## 概要
worklog の完了記録を自動化するため、`done` コマンドと `post-merge` フックを追加した。

---

## 設計概要
エージェントの責務（feature→develop PR 作成まで）を変えず、`main` ブランチへの `git pull` / `git merge` という既存の手順に worklog 更新を自然に組み込む。

---

## 実装概要
| ファイル | 変更内容 |
|---|---|
| `scripts/worklog.mjs` | `done` コマンド追加（`appendDoneEntry` 関数） |
| `package.json` | `worklog:done` スクリプト追加 |
| `.husky/post-merge` | 新規作成。`main` ブランチでのマージ完了時に `worklog:done` を自動実行 |
| `.github/copilot-instructions.md` | worklog 完了記録ルールを明文化（post-merge フック説明追加） |

---

## 実行した検証コマンドと結果
```
npm run build      → 成功
node scripts/worklog.mjs done --summary "テスト" --tags "test"
  → Worklog done entry appended: .worklog/logs/2026-05-08.md
```

---

## 手動動作確認
- `npm run worklog:done` で当日ログにエントリが追記されることを確認
- `post-merge` フックが `main` ブランチ判定時のみ実行することをスクリプト内容で確認

---

## 既知の未解決事項
なし