### PR TITLE
chore: Merge develop into main (Issue #245 included)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -102,4 +105,5 @@ jobs:
         with:
           name: playwright-report
           path: playwright-report/
+          if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'
@@ -28,7 +28,7 @@ jobs:
       - name: Run tests with coverage
         run: npm run test:coverage
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: coverage-report
           path: coverage
@@ -47,7 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'
@@ -55,7 +55,7 @@ jobs:
         run: npm ci
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -97,7 +97,7 @@ jobs:
         run: npm run test:ui
         timeout-minutes: 10
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: playwright-report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run tests with coverage
         run: npm run test:coverage
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-report
           path: coverage
@@ -101,7 +101,7 @@ jobs:
         run: npx playwright test --reporter=list,html
         timeout-minutes: 10
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: playwright-report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,8 @@ jobs:
           SUPABASE_ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           ACCESS_PASSWORD: ${{ secrets.ACCESS_PASSWORD }}
-        run: npm run test:ui
+          PLAYWRIGHT_HTML_OPEN: never
+        run: npx playwright test --reporter=list,html
         timeout-minutes: 10
       - name: Upload Playwright report
         uses: actions/upload-artifact@v5
@@ -105,5 +106,4 @@ jobs:
         with:
           name: playwright-report
           path: playwright-report/
-          if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
   unit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Use Node.js
         uses: actions/setup-node@v5
         with:
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [unit]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Use Node.js
         uses: actions/setup-node@v5
         with:

--- a/.specify/specs/issue-245-github-actions-nodejs-20-deprecation/plan.md
+++ b/.specify/specs/issue-245-github-actions-nodejs-20-deprecation/plan.md
@@ -1,0 +1,71 @@
+# Implementation Plan: GitHub Actions の Node.js 20 非推奨警告への対応
+
+**Feature Branch**: `feature/issue-245-github-actions-nodejs-20-deprecation`  
+**Last Updated**: 2026-05-09
+
+---
+
+## 実装戦略
+
+### フェーズ 1: 情報収集と検証
+
+1. GitHub Actions の各 action バージョンを確認
+   - `actions/checkout` のサポート状況（v4 が Node.js 24 対応か、v5 の有無確認）
+   - `actions/setup-node` のサポート状況（v4 が Node.js 24 対応か、v5 の有無確認）
+   - `actions/cache` のサポート状況（v4 が Node.js 24 対応か、v5 の有無確認）
+   - `actions/upload-artifact` のサポート状況（v4 が Node.js 24 対応か、v5 の有無確認）
+
+2. 各 action の最新バージョンをリポジトリに適用
+   - v4 が Node.js 24 対応なら、タグ更新のみで解消
+   - v5 以上が必要なら、バージョン昇格を実施
+
+### フェーズ 2: 実装と検証
+
+1. `.github/workflows/ci.yml` を更新
+   - 各 action のバージョンを Node.js 24 対応版に変更
+   - CI を実行してテスト成功を確認
+
+2. CI ログで警告消失を検証
+   - Node.js 20 非推奨警告が出力されないことを確認
+   - 既存の unit / integration ジョブが従来通り成功すること
+
+3. 変更前後の比較確認
+   - CI 実行時間の増減確認
+   - 新しい警告やエラーの有無確認
+
+---
+
+## 変更の概要
+
+| 対象 | 現在 | 変更予定 | 理由 |
+|---|---|---|---|
+| actions/checkout | v4 | v4（対応確認後） / v5+ | Node.js 24 対応版へ昇格 |
+| actions/setup-node | v4 | v4（対応確認後） / v5+ | Node.js 24 対応版へ昇格 |
+| actions/cache | v4 | v4（対応確認後） / v5+ | Node.js 24 対応版へ昇格 |
+| actions/upload-artifact | v4 | v4（対応確認後） / v5+ | Node.js 24 対応版へ昇格 |
+
+---
+
+## リスク・影響範囲
+
+| リスク | 対応 |
+|---|---|
+| アクション昇格による互換性破損 | 各 action の GitHub リポジトリで Node.js 24 対応の確認をしてから昇格 |
+| CI 実行時間の増加 | 変更前後で実行時間を計測し、閾値（unit 75s/integration 187s の±20%）超過時は見直す |
+| 他の GitHub workflow への波及 | 本課題では `.github/workflows/ci.yml` のみ対象。必要に応じて後続課題で管理 |
+
+---
+
+## 検証方針
+
+1. **ローカル検証**: yaml 構文エラーがないか確認
+2. **CI 検証**: GitHub Actions で実際に実行し、警告消失と動作確認
+3. **ドキュメント**: PR 本文に変更内容と検証結果を記載
+
+---
+
+## 実装スケジュール
+
+- **1日目**: 情報収集 + plan.md / tasks.md 確定
+- **2日目**: `.github/workflows/ci.yml` 更新 + CI 実行 + PR 作成
+- **マージ**: develop → main PR で進める

--- a/.specify/specs/issue-245-github-actions-nodejs-20-deprecation/spec.md
+++ b/.specify/specs/issue-245-github-actions-nodejs-20-deprecation/spec.md
@@ -1,0 +1,50 @@
+# Feature Specification: GitHub Actions の Node.js 20 非推奨警告への対応
+
+**Feature Branch**: `feature/issue-245-github-actions-nodejs-20-deprecation`  
+**Created**: 2026-05-09  
+**Status**: Draft  
+**Related Issue**: #245
+
+---
+
+## 背景・目的
+
+GitHub Actions の runner で Node.js 20 が非推奨となり、2026-06-02 から Node.js 24 がデフォルトになる予定です。現在の `.github/workflows/ci.yml` では以下のアクションが Node.js 20 ベースで実行されており、将来的に CI が破綻する可能性があります。
+
+- `actions/checkout@v4`
+- `actions/setup-node@v4`
+- `actions/cache@v4`
+- `actions/upload-artifact@v4`
+
+このアラートを解消し、Node.js 24 での安定実行を確保する。
+
+---
+
+## User Stories
+
+### US1 — GitHub Actions の非推奨警告解消 (Priority: P1)
+
+CI ログの警告「Node.js 20 actions are deprecated」を消して、CI 安定性を確保したい。
+
+**Acceptance Scenarios**:
+1. **Given** CI が実行される, **When** `.github/workflows/ci.yml` が最新版 actions を使用している, **Then** Node.js 20 非推奨警告が出力されない
+2. **Given** CI ジョブが実行される, **When** unit / integration ジョブが従来通り成功する, **Then** 動作は維持される
+3. **Given** Node.js 24 切り替え日以降, **When** CI が実行される, **Then** アクションが正常に動作し続ける
+
+---
+
+## 受け入れ基準
+
+- 対象: `.github/workflows/ci.yml`
+- 目標: Node.js 20 非推奨警告が CI ログから消える
+- 品質条件:
+  - `npm run build` 成功
+  - `npm run lint` 成功（CI上）
+  - `npm run test:coverage` / `test:integration` / `test:e2e` / `test:ui` 成功（CI上）
+  - CI 実行時間が大幅に増加しない（current: unit 75s + integration 187s）
+
+## 非スコープ
+
+- GitHub Actions CLI の更新（actions/github-script など）
+- 他の GitHub workflow ファイルの更新（必要なら後続課題として別管理）
+- Node.js ランタイム自体のアップグレード（リポジトリの node_version は現行 20 のまま保持）

--- a/.specify/specs/issue-245-github-actions-nodejs-20-deprecation/tasks.md
+++ b/.specify/specs/issue-245-github-actions-nodejs-20-deprecation/tasks.md
@@ -1,0 +1,95 @@
+# Task Breakdown: GitHub Actions の Node.js 20 非推奨警告への対応
+
+**Feature Branch**: `feature/issue-245-github-actions-nodejs-20-deprecation`  
+**Total Tasks**: 6  
+**Last Updated**: 2026-05-09
+
+---
+
+## Task List
+
+### Task 1: 各 GitHub Action のサポート状況を確認
+- **Description**: 
+  - `actions/checkout` が Node.js 24 対応か確認（v4 のままか v5 に昇格するか）
+  - `actions/setup-node` が Node.js 24 対応か確認
+  - `actions/cache` が Node.js 24 対応か確認
+  - `actions/upload-artifact` が Node.js 24 対応か確認
+- **Acceptance**: 各 action の GitHub リポジトリまたはドキュメントで Node.js 24 対応状況を確認し、対応バージョンを特定できた
+- **Depends on**: なし
+- **Estimated**: 30m
+
+### Task 2: `.github/workflows/ci.yml` を更新
+- **Description**: 
+  - Task 1 の結果に基づき、各 action のバージョンを更新
+  - 例: `actions/checkout@v4` → `actions/checkout@v4` (v4 が対応の場合) / `actions/checkout@v5` (昇格が必要な場合)
+  - 複数行の変更が発生する可能性あり
+- **Acceptance**: yaml が有効で、変更内容が Plan に合致している
+- **Depends on**: Task 1
+- **Estimated**: 20m
+
+### Task 3: ローカルで yaml 構文を検証
+- **Description**: 
+  - 更新した `.github/workflows/ci.yml` の yaml 構文が正しいか確認
+  - IDE や `yamllint` などで構文チェック（不要なら不実施と明記）
+- **Acceptance**: yaml 構文エラーがない
+- **Depends on**: Task 2
+- **Estimated**: 10m
+
+### Task 4: `npm run build` / `npm run lint` を実行し成功を確認
+- **Description**: 
+  - コード変更がないため、ビルド・lint は確認の意味でのみ実行
+  - 失敗時は原因を特定して対応
+- **Acceptance**: `npm run build` と `npm run lint` が成功
+- **Depends on**: Task 3
+- **Estimated**: 10m
+
+### Task 5: GitHub Actions で CI を実行し、警告消失と動作確認
+- **Description**: 
+  - 更新した workflow で CI を実行
+  - CI ログで "Node.js 20 actions are deprecated" 警告が消えたことを確認
+  - unit / integration ジョブが従来通り成功することを確認
+  - 実行時間の増減を記録
+- **Acceptance**: 
+  - Node.js 20 非推奨警告がログに出力されない
+  - unit / integration ジョブが成功
+  - CI 実行時間が大幅に増加していない（±20% 以内）
+- **Depends on**: Task 2 (CI push 実行後)
+- **Estimated**: 15m
+
+### Task 6: コミット・push・PR 作成
+- **Description**: 
+  - 変更をローカルでコミット
+  - feature ブランチを push
+  - develop ベースの PR を作成（PR 本文に Task 5 の検証結果を記載）
+  - コミット前に `npm run build` 成功を確認する（必須）
+- **Acceptance**: 
+  - develop ベースの PR が作成できた
+  - PR 本文に設計概要 / 実装概要 / 検証結果 / 未解決事項を記載
+- **Depends on**: Task 5
+- **Estimated**: 15m
+
+---
+
+## 依存関係図
+
+```
+Task 1 (確認)
+   ↓
+Task 2 (更新)
+   ↓
+Task 3 (構文検証)
+   ↓
+Task 4 (ローカルビルド)
+   ↓
+Task 5 (CI 実行)
+   ↓
+Task 6 (PR 作成)
+```
+
+---
+
+## 実装上の注意点
+
+- **Task 1 の重要性**: 誤ったバージョンに更新すると CI が破綻するため、必ず GitHub Actions のドキュメントで確認
+- **yaml 構文**: インデント誤りは yaml パーサーで検出不可の場合があるため、視認確認も併せて実施
+- **CI ログ**: 警告消失の確認は CI ラン全体のログを見ること（step ごとの圧縮ログではなく）

--- a/docs/issue-prompt-guidelines.md
+++ b/docs/issue-prompt-guidelines.md
@@ -26,7 +26,7 @@
 1) Clarify（確認用）
 
 ```text
-Issue #<番号> を対応します。次を教えてください。
+Issue # を対応します。次を教えてください。
 1) 目的の要約
 2) 期待挙動（現状と理想）
 3) 優先度・期限
@@ -38,7 +38,7 @@ Issue #<番号> を対応します。次を教えてください。
 2) Design（設計フェーズ専用・実装禁止）
 
 ```text
-Issue #<番号> の設計フェーズのみ実施してください。
+Issue # の設計フェーズのみ実施してください。
 
 要件:
 - `.specify/specs/<feature>/spec.md`
@@ -59,12 +59,12 @@ Issue #<番号> の設計フェーズのみ実施してください。
 3) Implement（実装フェーズ専用）
 
 ```text
-Issue #<番号> は設計承認済みです。実装フェーズを実施してください。
+Issue # は設計承認済みです。実装フェーズを実施してください。
 
 開始前チェック:
 1) spec/plan/tasks の3点が存在すること
 2) 当日worklogを起票すること
-	`npm run worklog:start -- --summary "Issue #<番号> 実装開始" --reason "..." --tags "issue-<番号>,implementation,worklog"`
+	`npm run worklog:start -- --summary "Issue # 実装開始" --reason "..." --tags "issue-<番号>,implementation,worklog"`
 
 実施内容:
 - tasks.md に従って最小差分で実装
@@ -108,7 +108,7 @@ Worklog:
 - <必要なら要点>
 
 関連 Issue:
-- #<番号>
+- #
 ```
 
 必要に応じて、PR本文では次の補足も追記してください。


### PR DESCRIPTION
# Summary

Merge develop branch into main, which includes Issue #245 GitHub Actions Node.js 24 compatibility fixes.

## Related Issue
- Closes #245

## Changes Overview

### GitHub Actions Workflow Updates (.github/workflows/ci.yml)
- Upgraded `actions/checkout` from v4 to v5 (Node.js 24 support)
- Upgraded `actions/setup-node` from v4 to v5 (Node.js 24 support)
- Upgraded `actions/cache` from v4 to v5 (Node.js 24 support)
- Upgraded `actions/upload-artifact` from v5 to v6 (Node.js 24 default runtime)
- Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'` env to streamline Node 24 opt-in

### Implementation Details
- Eliminated Node.js 20 deprecation warnings from CI logs
- Enabled Playwright HTML report generation (`--reporter=list,html`)
- Design artifacts created: spec.md, plan.md, tasks.md for Issue #245

## Verification Results

### CI Pipeline
- ✅ unit test: 1m8s (PASSED)
- ✅ integration test: 3m33s (PASSED)
- ✅ Node.js 20 deprecation warning: RESOLVED (no longer in logs)
- ✅ All checks: PASSED

### Local Validation
- ✅ npm run build: Success
- ✅ npm run lint: Success (existing warnings only)

### Manual Verification
- ✅ workflow YAML syntax: Valid
- ✅ GitHub Actions runner support: Confirmed (v2.334.0 with Node 24 opt-in)
- ✅ Playwright artifact generation: Confirmed

## Known Issues
- None

## Breaking Changes
- None. All changes are backward compatible.
