### PR TITLE
fix: 相性表の試合数フィルタセレクト同期バグ修正 (#121)

### DIFF
--- a/app/compatibility/page.tsx
+++ b/app/compatibility/page.tsx
@@ -132,7 +132,13 @@ export default async function CompatibilityPage({ searchParams }: { searchParams
                   initialStart={start}
                   initialEnd={end}
                   initialTournamentId={tournamentId ? String(tournamentId) : undefined}
-                  initialMinGames={effectiveMinGames !== undefined ? String(effectiveMinGames) : undefined}
+                  initialMinGames={
+                    initialMinGamesRaw !== undefined
+                      ? initialMinGamesRaw
+                      : filter === "year"
+                        ? "20"
+                        : ""
+                  }
                   showMinGames={true}
                   actionPath="/compatibility"
                   availableDates={datesError ? undefined : availableDates}


### PR DESCRIPTION
設計概要:
- 相性表画面で「今年」選択時に「試合数：条件なし」を選ぶと、データは条件なしで更新される一方、セレクト表示だけ「20試合以上」に戻る不整合を解消
- 成績集計画面の実装（`initialMinGamesRaw` を優先）との整合性を取り、URL クエリの空文字（`minGames=`）を UI 初期値に正しく反映
- Spec Kit: `.specify/specs/121-minGames-select-sync/spec.md` / `plan.md` / `tasks.md`

実装概要:
- `app/compatibility/page.tsx` の `DateRangeFilter` への `initialMinGames` 引き渡しを修正
- 変更前: `effectiveMinGames` 由来（空文字が `undefined` 化される）
- 変更後: `initialMinGamesRaw` を優先して渡す（`minGames=` の空文字を保持）

実行した検証コマンドと結果:
- `npm run build`: 成功
- `npm run lint`: 成功（既存警告2件あり、今回変更とは無関係）
  - `app/user-actions.ts` の `@typescript-eslint/no-unused-vars`
  - `lib/stats-rank-theme.ts` の `import/no-anonymous-default-export`
- `npm test --silent`: 成功（全テスト pass）

手動動作確認の内容:
- 相性表で「今年」+「試合数：条件なし」を選択
- 相性表データが条件なしで更新されることを確認
- ブラウザ再読込（F5）後も試合数セレクトが「条件なし」を維持することを確認
- 「20試合以上」へ再変更した場合も表示・データが一致することを確認

既知の未解決事項:
- なし（既存の lint 警告2件は今回スコープ外）

Worklog:
- `.worklog/logs/2026-05-10.md` に実装開始ログを記録済み
- Summary: `Issue #121 実装開始: 相性表 minGames セレクト同期修正`
- Tags: `issue-121,implementation,worklog`

関連 Issue:
- #121
