### PR TITLE
chore: エージェント運用テンプレート整備 (#254)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,13 +5,21 @@
 * **目的:** 手書きの麻雀スコア表（画像）から、アプリ投入用の正確なマスターデータを抽出・管理する。
 * **主要技術:**
     * **Database/Auth:** Supabase (PostgreSQL)（※暫定でGoogleスプレッドシートを使用）
-    * **Frontend:** TypeScript / React (Vite推奨)
+    * **Frontend:** Next.js 15 (App Router) / React 19 / TypeScript
     * **Logic:** TypeScript (Node.js)
 * **ドメイン知識:**
     * **麻雀:** 四人打ち・三人打ちの両方のスコア体系を考慮した拡張性を持たせる。
 * **回答スタイル:** 技術的正確性を最優先し、簡潔に回答する。リストや段落を活用し、絵文字の使用頻度は低く抑える。
 
+## 1.1 Agent Quickstart (最小セット)
+* **最初に確認するファイル:** `README.md`、`docs/agent-delegation-guide.md`、`docs/issue-prompt-guidelines.md`
+* **最低限の検証コマンド:** `npm run build`（必須）、可能なら `npm run lint` と `npm test`
+* **ローカルDB前提:** local Supabase を利用し、staging / production の URL・キーを `.env.local` に設定しない
+* **スキーマ運用:** 正本は `supabase/migrations/`。`ddl/` は参照専用（read-only）
+* **worklog:** 実装フェーズ開始時に `npm run worklog:start -- --summary "Issue #<番号> 実装開始" --reason "..." --tags "issue-<番号>,implementation,worklog"`
+
 ## 2. Git & Pull Request Operation Rules
+* **詳細ガイドの参照先:** 実行手順テンプレートは `docs/agent-delegation-guide.md`、Issue 依頼テンプレートは `docs/issue-prompt-guidelines.md` を優先参照すること。
 * **委任範囲の既定:** 作業フローは「設計フェーズ」と「実装フェーズ」の2段階で運用する。設計フェーズ（Issue読み取り → 設計資料作成 → エージェント自己レビュー）完了後にユーザー確認のため必ず停止する。ユーザーが設計を承認してから実装フェーズ（実装 → テスト → 動作確認 → コミット → push → PR作成）を委任された場合のみ、途中確認なしで完遂を目指すこと。
 * **コミット制限:** 自動コミットを許可します。ユーザーの明示的な指示がない場合でも、変更内容が適切であればローカルでコミットを実行してよい。ただし、機密情報（APIキー、トークン、秘密鍵、個人情報）を含む変更はコミットしないこと。
 * **Push制限:** `git push` の自動実行を許可します。ユーザーの明示的な依頼がない場合でも、作業ブランチを作成して変更をリモートへ push してよい。

--- a/.github/instructions/local-supabase-safety.instructions.md
+++ b/.github/instructions/local-supabase-safety.instructions.md
@@ -1,0 +1,34 @@
+---
+applyTo: "{app/**/*-actions.ts,app/api/**/route.ts,lib/**/*.ts,scripts/**/*.mjs,test/e2e/ui/**/*.ts}"
+description: "Use when editing server-side code that touches DB/auth/env. Enforce local Supabase safety and prevent remote URL/key usage in local workflows."
+---
+
+# Local Supabase Safety Guardrails
+
+この指示は local 開発時の接続先事故を防ぐためのガードです。
+既存ドキュメントを優先参照し、重複説明はしないこと。
+
+参照先:
+- `README.md`（local Supabase 手順と禁止事項）
+- `docs/migration-runbook.md`（移行運用）
+- `ddl/README.md`（`ddl/` は read-only）
+
+## MUST
+
+- local 開発向け変更では、staging/production の URL・キーを `.env.local` に書き込む提案をしない。
+- `SUPABASE_URL` / `DATABASE_URL` が remote を指す可能性がある変更は、明示的にリスクを説明する。
+- DB スキーマ変更は `supabase/migrations/` に追加する。`ddl/` を適用ソースとして扱わない。
+- 接続前に env の存在チェックを行い、未設定時は安全に失敗させる。
+- PR/説明には、最低1つの実施コマンド結果を含める（最低基準は `npm run build`）。
+
+## SHOULD
+
+- local DB 前提の変更では `npm run check:local-db` または `npm run check:local-db:strict` を検討する。
+- UI/E2E 変更では `npm run test:ui:preflight` の必要性を評価し、未実施なら理由を残す。
+- env 差分に触れる場合は、機密情報をマスクした記述のみを残す。
+
+## Avoid
+
+- `.env.local` の値を具体値つきでコミット用差分として提案する。
+- 「`ddl/` を更新すれば反映される」という案内。
+- local 検証を飛ばして remote 環境前提で動作確認を書くこと。

--- a/.github/prompts/pr-body-from-changes.prompt.md
+++ b/.github/prompts/pr-body-from-changes.prompt.md
@@ -1,0 +1,28 @@
+---
+mode: agent
+description: "Generate a PR body from current changes in this repository using the required template sections and validation results."
+---
+
+現在の変更差分をもとに、このリポジトリの運用ルールに沿った PR 本文を作成してください。
+
+要件:
+- 必須セクションをこの順序で出力する。
+  1. 設計概要
+  2. 実装概要
+  3. 実行した検証コマンドと結果
+  4. 手動動作確認の内容
+  5. 既知の未解決事項
+  6. Worklog
+  7. 関連 Issue
+- 実行済みコマンドが不足する場合は、未実施として理由を明記する。
+- 事実不明の内容は断定しない。
+- 箇条書き中心で簡潔にまとめる。
+
+参照:
+- `.github/PULL_REQUEST_TEMPLATE.md`
+- `.github/copilot-instructions.md`
+- `docs/issue-prompt-guidelines.md`
+
+出力形式:
+- Markdown のみ
+- そのまま PR 本文に貼れる完成形

--- a/.github/skills/issue-implementation-runbook/SKILL.md
+++ b/.github/skills/issue-implementation-runbook/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: issue-implementation-runbook
+description: "Use when: implementing an approved GitHub Issue end-to-end in this repository (worklog start, minimal diff implementation, verification, commit/push, PR body requirements)."
+---
+
+# Issue Implementation Runbook
+
+このスキルは、このリポジトリで設計承認後の実装フェーズを通しで進めるための手順です。
+既存ルールを複製せず、必要箇所へリンクして実行順のみを固定します。
+
+## Input
+
+- Issue 番号
+- 対象 spec ディレクトリ（`.specify/specs/<feature>/`）
+- 実装対象のスコープ（UI/API/DB/バッチ）
+
+## Step 1: Preconditions
+
+- 設計3点 (`spec.md` / `plan.md` / `tasks.md`) が存在するか確認する。
+- 参照:
+  - `.github/copilot-instructions.md`
+  - `docs/agent-delegation-guide.md`
+  - `docs/issue-prompt-guidelines.md`
+
+## Step 2: Start Worklog
+
+- 実装着手前に当日 worklog を起票:
+  - `npm run worklog:start -- --summary "Issue #<番号> 実装開始" --reason "..." --tags "issue-<番号>,implementation,worklog"`
+
+## Step 3: Implement With Minimal Diff
+
+- `tasks.md` の順序と依存関係を守る。
+- 無関係なリファクタやフォーマット変更を避ける。
+- 認証・認可・機密情報に触れる場合はリスクを明記する。
+
+## Step 4: Verify
+
+- 必須: `npm run build`
+- 可能なら: `npm run lint`、`npm test`
+- 変更種別に応じて必要な手動確認を記録する。
+
+## Step 5: Commit, Push, PR
+
+- ビルド成功後にコミットする。
+- push 後、PR 本文に以下を必ず記載する:
+  - 設計概要
+  - 実装概要
+  - 実行した検証コマンドと結果
+  - 手動動作確認の内容
+  - 既知の未解決事項
+  - Worklog 記録
+
+## Output Checklist
+
+- [ ] 実装差分が最小
+- [ ] `npm run build` 成功
+- [ ] PR 本文の必須項目を充足
+- [ ] `.worklog/logs/YYYY-MM-DD.md` に記録あり

--- a/docs/issue-prompt-guidelines.md
+++ b/docs/issue-prompt-guidelines.md
@@ -6,10 +6,8 @@
 **基本方針（必須）**
 - フェーズは必ず 2 段階: 設計フェーズ -> 実装フェーズ
 - 設計フェーズ完了時は必ず停止し、ユーザー承認を待つ
-- 実装開始前に Spec Kit 3点セットを揃える
-: `.specify/specs/<feature>/spec.md`, `.specify/specs/<feature>/plan.md`, `.specify/specs/<feature>/tasks.md`
-- 実装開始時点で当日 worklog を起票する
-: `npm run worklog:start -- --summary "..." --reason "..." --tags "issue-<番号>,..."`
+- 実装開始前に Spec Kit 3点セットを揃える（`.specify/specs/<feature>/spec.md`, `.specify/specs/<feature>/plan.md`, `.specify/specs/<feature>/tasks.md`）
+- 実装開始時点で当日 worklog を起票する（`npm run worklog:start -- --summary "..." --reason "..." --tags "issue-<番号>,..."`）
 - PR 本文には必須項目 + Worklog 記載を入れる
 
 ---
@@ -57,6 +55,8 @@ Issue # の設計フェーズのみ実施してください。
 ```
 
 3) Implement（実装フェーズ専用）
+
+最短で依頼する場合は、この章のテンプレートをそのまま送ってください。
 
 ```text
 Issue # は設計承認済みです。実装フェーズを実施してください。
@@ -139,3 +139,8 @@ PR が main にマージされたら、develop を除く取り込み済みブラ
 **注記**
 - 機密情報はプロンプトやドキュメントに含めないこと。
 - 失敗したコマンドや未実施項目は、理由を PR 本文に必ず明記すること。
+
+---
+**関連カスタマイズ（任意）**
+- PR本文を差分から自動生成する場合: `.github/prompts/pr-body-from-changes.prompt.md`
+- 実装フェーズの手順を固定する場合: `.github/skills/issue-implementation-runbook/SKILL.md`


### PR DESCRIPTION
設計概要:
- エージェント運用の再現性向上を目的に、Issue 実装手順・安全ガード・PR本文生成を整備。
- Spec Kit 代替: 本件は軽微な運用改善のため、`docs/issue-prompt-guidelines.md` に手順を明文化。

実装概要:
- `.github/copilot-instructions.md`
  - 技術スタック表記を実態へ更新（Next.js 15 / React 19）。
  - Agent Quickstart と参照導線を追加。
- `.github/instructions/local-supabase-safety.instructions.md` を追加。
- `.github/skills/issue-implementation-runbook/SKILL.md` を追加。
- `.github/prompts/pr-body-from-changes.prompt.md` を追加。
- `docs/issue-prompt-guidelines.md`
  - Implement セクションを一本化し、重複テンプレートを整理。

実行した検証コマンドと結果:
- `npm run build`: 成功
- `npm run lint`: 成功（Warning 2件: `app/user-actions.ts` unused var, `lib/stats-rank-theme.ts` anonymous default export）
- `npm test`: 成功（unit/integration/e2e すべて pass）

手動動作確認の内容:
- ドキュメント導線（copilot instructions -> docs）の参照関係を確認。
- Issue 実装テンプレートが Clarify/Design/Implement/PR の順で利用可能であることを確認。
- 新規 instruction/skill/prompt の配置パスと内容を確認。

既知の未解決事項:
- なし

Worklog:
- `.worklog/logs/2026-05-12.md` に Issue #254 実装開始を記録済み。
- `done_when`: main マージ後に `npm run worklog:done` を実行。

関連 Issue:
- #254
