### PR TITLE
Release: エージェント運用テンプレート整備

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,13 +5,21 @@
 * **目的:** 手書きの麻雀スコア表（画像）から、アプリ投入用の正確なマスターデータを抽出・管理する。
 * **主要技術:**
     * **Database/Auth:** Supabase (PostgreSQL)（※暫定でGoogleスプレッドシートを使用）
-    * **Frontend:** TypeScript / React (Vite推奨)
+    * **Frontend:** Next.js 15 (App Router) / React 19 / TypeScript
     * **Logic:** TypeScript (Node.js)
 * **ドメイン知識:**
     * **麻雀:** 四人打ち・三人打ちの両方のスコア体系を考慮した拡張性を持たせる。
 * **回答スタイル:** 技術的正確性を最優先し、簡潔に回答する。リストや段落を活用し、絵文字の使用頻度は低く抑える。
 
+## 1.1 Agent Quickstart (最小セット)
+* **最初に確認するファイル:** `README.md`、`docs/agent-delegation-guide.md`、`docs/issue-prompt-guidelines.md`
+* **最低限の検証コマンド:** `npm run build`（必須）、可能なら `npm run lint` と `npm test`
+* **ローカルDB前提:** local Supabase を利用し、staging / production の URL・キーを `.env.local` に設定しない
+* **スキーマ運用:** 正本は `supabase/migrations/`。`ddl/` は参照専用（read-only）
+* **worklog:** 実装フェーズ開始時に `npm run worklog:start -- --summary "Issue #<番号> 実装開始" --reason "..." --tags "issue-<番号>,implementation,worklog"`
+
 ## 2. Git & Pull Request Operation Rules
+* **詳細ガイドの参照先:** 実行手順テンプレートは `docs/agent-delegation-guide.md`、Issue 依頼テンプレートは `docs/issue-prompt-guidelines.md` を優先参照すること。
 * **委任範囲の既定:** 作業フローは「設計フェーズ」と「実装フェーズ」の2段階で運用する。設計フェーズ（Issue読み取り → 設計資料作成 → エージェント自己レビュー）完了後にユーザー確認のため必ず停止する。ユーザーが設計を承認してから実装フェーズ（実装 → テスト → 動作確認 → コミット → push → PR作成）を委任された場合のみ、途中確認なしで完遂を目指すこと。
 * **コミット制限:** 自動コミットを許可します。ユーザーの明示的な指示がない場合でも、変更内容が適切であればローカルでコミットを実行してよい。ただし、機密情報（APIキー、トークン、秘密鍵、個人情報）を含む変更はコミットしないこと。
 * **Push制限:** `git push` の自動実行を許可します。ユーザーの明示的な依頼がない場合でも、作業ブランチを作成して変更をリモートへ push してよい。

--- a/.github/instructions/local-supabase-safety.instructions.md
+++ b/.github/instructions/local-supabase-safety.instructions.md
@@ -1,0 +1,34 @@
+---
+applyTo: "{app/**/*-actions.ts,app/api/**/route.ts,lib/**/*.ts,scripts/**/*.mjs,test/e2e/ui/**/*.ts}"
+description: "Use when editing server-side code that touches DB/auth/env. Enforce local Supabase safety and prevent remote URL/key usage in local workflows."
+---
+
+# Local Supabase Safety Guardrails
+
+この指示は local 開発時の接続先事故を防ぐためのガードです。
+既存ドキュメントを優先参照し、重複説明はしないこと。
+
+参照先:
+- `README.md`（local Supabase 手順と禁止事項）
+- `docs/migration-runbook.md`（移行運用）
+- `ddl/README.md`（`ddl/` は read-only）
+
+## MUST
+
+- local 開発向け変更では、staging/production の URL・キーを `.env.local` に書き込む提案をしない。
+- `SUPABASE_URL` / `DATABASE_URL` が remote を指す可能性がある変更は、明示的にリスクを説明する。
+- DB スキーマ変更は `supabase/migrations/` に追加する。`ddl/` を適用ソースとして扱わない。
+- 接続前に env の存在チェックを行い、未設定時は安全に失敗させる。
+- PR/説明には、最低1つの実施コマンド結果を含める（最低基準は `npm run build`）。
+
+## SHOULD
+
+- local DB 前提の変更では `npm run check:local-db` または `npm run check:local-db:strict` を検討する。
+- UI/E2E 変更では `npm run test:ui:preflight` の必要性を評価し、未実施なら理由を残す。
+- env 差分に触れる場合は、機密情報をマスクした記述のみを残す。
+
+## Avoid
+
+- `.env.local` の値を具体値つきでコミット用差分として提案する。
+- 「`ddl/` を更新すれば反映される」という案内。
+- local 検証を飛ばして remote 環境前提で動作確認を書くこと。

--- a/.github/prompts/pr-body-from-changes.prompt.md
+++ b/.github/prompts/pr-body-from-changes.prompt.md
@@ -1,0 +1,28 @@
+---
+mode: agent
+description: "Generate a PR body from current changes in this repository using the required template sections and validation results."
+---
+
+現在の変更差分をもとに、このリポジトリの運用ルールに沿った PR 本文を作成してください。
+
+要件:
+- 必須セクションをこの順序で出力する。
+  1. 設計概要
+  2. 実装概要
+  3. 実行した検証コマンドと結果
+  4. 手動動作確認の内容
+  5. 既知の未解決事項
+  6. Worklog
+  7. 関連 Issue
+- 実行済みコマンドが不足する場合は、未実施として理由を明記する。
+- 事実不明の内容は断定しない。
+- 箇条書き中心で簡潔にまとめる。
+
+参照:
+- `.github/PULL_REQUEST_TEMPLATE.md`
+- `.github/copilot-instructions.md`
+- `docs/issue-prompt-guidelines.md`
+
+出力形式:
+- Markdown のみ
+- そのまま PR 本文に貼れる完成形

--- a/.github/skills/issue-implementation-runbook/SKILL.md
+++ b/.github/skills/issue-implementation-runbook/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: issue-implementation-runbook
+description: "Use when: implementing an approved GitHub Issue end-to-end in this repository (worklog start, minimal diff implementation, verification, commit/push, PR body requirements)."
+---
+
+# Issue Implementation Runbook
+
+このスキルは、このリポジトリで設計承認後の実装フェーズを通しで進めるための手順です。
+既存ルールを複製せず、必要箇所へリンクして実行順のみを固定します。
+
+## Input
+
+- Issue 番号
+- 対象 spec ディレクトリ（`.specify/specs/<feature>/`）
+- 実装対象のスコープ（UI/API/DB/バッチ）
+
+## Step 1: Preconditions
+
+- 設計3点 (`spec.md` / `plan.md` / `tasks.md`) が存在するか確認する。
+- 参照:
+  - `.github/copilot-instructions.md`
+  - `docs/agent-delegation-guide.md`
+  - `docs/issue-prompt-guidelines.md`
+
+## Step 2: Start Worklog
+
+- 実装着手前に当日 worklog を起票:
+  - `npm run worklog:start -- --summary "Issue #<番号> 実装開始" --reason "..." --tags "issue-<番号>,implementation,worklog"`
+
+## Step 3: Implement With Minimal Diff
+
+- `tasks.md` の順序と依存関係を守る。
+- 無関係なリファクタやフォーマット変更を避ける。
+- 認証・認可・機密情報に触れる場合はリスクを明記する。
+
+## Step 4: Verify
+
+- 必須: `npm run build`
+- 可能なら: `npm run lint`、`npm test`
+- 変更種別に応じて必要な手動確認を記録する。
+
+## Step 5: Commit, Push, PR
+
+- ビルド成功後にコミットする。
+- push 後、PR 本文に以下を必ず記載する:
+  - 設計概要
+  - 実装概要
+  - 実行した検証コマンドと結果
+  - 手動動作確認の内容
+  - 既知の未解決事項
+  - Worklog 記録
+
+## Output Checklist
+
+- [ ] 実装差分が最小
+- [ ] `npm run build` 成功
+- [ ] PR 本文の必須項目を充足
+- [ ] `.worklog/logs/YYYY-MM-DD.md` に記録あり

--- a/docs/issue-prompt-guidelines.md
+++ b/docs/issue-prompt-guidelines.md
@@ -6,10 +6,8 @@
 **基本方針（必須）**
 - フェーズは必ず 2 段階: 設計フェーズ -> 実装フェーズ
 - 設計フェーズ完了時は必ず停止し、ユーザー承認を待つ
-- 実装開始前に Spec Kit 3点セットを揃える
-: `.specify/specs/<feature>/spec.md`, `.specify/specs/<feature>/plan.md`, `.specify/specs/<feature>/tasks.md`
-- 実装開始時点で当日 worklog を起票する
-: `npm run worklog:start -- --summary "..." --reason "..." --tags "issue-<番号>,..."`
+- 実装開始前に Spec Kit 3点セットを揃える（`.specify/specs/<feature>/spec.md`, `.specify/specs/<feature>/plan.md`, `.specify/specs/<feature>/tasks.md`）
+- 実装開始時点で当日 worklog を起票する（`npm run worklog:start -- --summary "..." --reason "..." --tags "issue-<番号>,..."`）
 - PR 本文には必須項目 + Worklog 記載を入れる
 
 ---
@@ -57,6 +55,8 @@ Issue # の設計フェーズのみ実施してください。
 ```
 
 3) Implement（実装フェーズ専用）
+
+最短で依頼する場合は、この章のテンプレートをそのまま送ってください。
 
 ```text
 Issue # は設計承認済みです。実装フェーズを実施してください。
@@ -139,3 +139,8 @@ PR が main にマージされたら、develop を除く取り込み済みブラ
 **注記**
 - 機密情報はプロンプトやドキュメントに含めないこと。
 - 失敗したコマンドや未実施項目は、理由を PR 本文に必ず明記すること。
+
+---
+**関連カスタマイズ（任意）**
+- PR本文を差分から自動生成する場合: `.github/prompts/pr-body-from-changes.prompt.md`
+- 実装フェーズの手順を固定する場合: `.github/skills/issue-implementation-runbook/SKILL.md`

--- a/scripts/cleanup-merged-branches.sh
+++ b/scripts/cleanup-merged-branches.sh
@@ -1,33 +1,63 @@
 #!/bin/sh
-# main へ取り込み済みの作業ブランチを整理する
-# - develop は保持
-# - 未マージブランチは削除しない
+# develop へ取り込み済みの作業ブランチを整理する
+# 条件:
+# - develop へ取り込み済み
+# - かつ develop が main へ取り込み済み
+# - develop/main は保持
 # - ローカルと origin の両方を対象にする
 
 set -u
 
+log() {
+  echo "[cleanup-merged-branches] $1"
+}
+
+DRY_RUN=0
+if [ "${1:-}" = "--dry-run" ]; then
+  DRY_RUN=1
+fi
+
 CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+log "start: branch=$CURRENT_BRANCH dry_run=$DRY_RUN"
 if [ "$CURRENT_BRANCH" != "main" ]; then
+  log "skip: current branch is not main ($CURRENT_BRANCH)"
   exit 0
 fi
 
 if ! git remote get-url origin >/dev/null 2>&1; then
-  echo "[cleanup-merged-branches] origin が見つからないためスキップします"
+  log "skip: origin が見つからないためスキップします"
   exit 0
 fi
 
 git fetch origin --prune >/dev/null 2>&1 || true
 
-if git show-ref --verify --quiet refs/remotes/origin/main; then
-  MERGED_BASE="origin/main"
-else
-  MERGED_BASE="main"
+if ! git show-ref --verify --quiet refs/remotes/origin/main; then
+  log "skip: origin/main が見つからないためスキップします"
+  exit 0
+fi
+
+if ! git show-ref --verify --quiet refs/remotes/origin/develop; then
+  log "skip: origin/develop が見つからないためスキップします"
+  exit 0
+fi
+
+# develop が main に取り込み済みでなければ、develop 取り込み済みブランチの削除は行わない
+if ! git merge-base --is-ancestor origin/develop origin/main; then
+  log "skip: origin/develop が origin/main に未取り込みのためスキップします"
+  exit 0
 fi
 
 CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "")
 
-# ローカルの取り込み済みブランチを削除
-for branch in $(git for-each-ref --format='%(refname:short)' --merged "$MERGED_BASE" refs/heads); do
+LOCAL_CANDIDATES=0
+LOCAL_DELETED=0
+LOCAL_SKIPPED=0
+REMOTE_CANDIDATES=0
+REMOTE_DELETED=0
+REMOTE_SKIPPED=0
+
+# ローカルの develop 取り込み済みブランチを削除
+for branch in $(git for-each-ref --format='%(refname:short)' --merged origin/develop refs/heads); do
   case "$branch" in
     ""|main|develop)
       continue
@@ -38,28 +68,47 @@ for branch in $(git for-each-ref --format='%(refname:short)' --merged "$MERGED_B
     continue
   fi
 
-  if git branch -d "$branch" >/dev/null 2>&1; then
-    echo "[cleanup-merged-branches] local deleted: $branch"
+  LOCAL_CANDIDATES=$((LOCAL_CANDIDATES + 1))
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "local candidate: $branch"
+  elif git branch -d "$branch" >/dev/null 2>&1; then
+    LOCAL_DELETED=$((LOCAL_DELETED + 1))
+    log "local deleted: $branch"
   else
-    echo "[cleanup-merged-branches] local skip: $branch"
+    LOCAL_SKIPPED=$((LOCAL_SKIPPED + 1))
+    log "local skip: $branch"
   fi
 done
 
-# リモートの取り込み済みブランチを削除
-if git show-ref --verify --quiet refs/remotes/origin/main; then
-  for remote_ref in $(git for-each-ref --format='%(refname:short)' --merged origin/main refs/remotes/origin); do
-    branch=${remote_ref#origin/}
+# リモートの develop 取り込み済みブランチを削除
+for remote_ref in $(git for-each-ref --format='%(refname:short)' --merged origin/develop refs/remotes/origin); do
+  case "$remote_ref" in
+    ""|origin|origin/HEAD|origin/main|origin/develop)
+      continue
+      ;;
+  esac
 
-    case "$branch" in
-      ""|HEAD|main|develop)
-        continue
-        ;;
-    esac
+  branch=${remote_ref#origin/}
 
-    if git push origin --delete "$branch" >/dev/null 2>&1; then
-      echo "[cleanup-merged-branches] remote deleted: origin/$branch"
-    else
-      echo "[cleanup-merged-branches] remote skip: origin/$branch"
-    fi
-  done
-fi
+  case "$branch" in
+    ""|origin|HEAD|main|develop)
+      continue
+      ;;
+  esac
+
+  REMOTE_CANDIDATES=$((REMOTE_CANDIDATES + 1))
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "remote candidate: origin/$branch"
+  elif git push origin --delete "$branch" >/dev/null 2>&1; then
+    REMOTE_DELETED=$((REMOTE_DELETED + 1))
+    log "remote deleted: origin/$branch"
+  else
+    REMOTE_SKIPPED=$((REMOTE_SKIPPED + 1))
+    log "remote skip: origin/$branch"
+  fi
+done
+
+log "summary: local candidates=$LOCAL_CANDIDATES deleted=$LOCAL_DELETED skipped=$LOCAL_SKIPPED"
+log "summary: remote candidates=$REMOTE_CANDIDATES deleted=$REMOTE_DELETED skipped=$REMOTE_SKIPPED"


### PR DESCRIPTION
Release: エージェント運用テンプレート整備を本番へ反映

## 概要

develop ブランチに統合済みのエージェント運用テンプレート・安全ガードを main に統合します。

## 含まれるコミット

- chore: add agent customization runbook and safety guard (refs #254)
  - Issue #254 の実装完了

## 変更内容

- `.github/copilot-instructions.md`
  - 技術スタック表記を実態へ更新（Next.js 15 / React 19）
  - Agent Quickstart と参照導線を追加
- `.github/instructions/local-supabase-safety.instructions.md` (新規)
  - local Supabase 前提の安全ガードを強制
- `.github/skills/issue-implementation-runbook/SKILL.md` (新規)
  - Issue 実装フェーズの手順化
- `.github/prompts/pr-body-from-changes.prompt.md` (新規)
  - PR 本文の自動生成支援
- `docs/issue-prompt-guidelines.md`
  - Implement セクションを一本化、テンプレート重複を整理

## マージ後の作業

- `npm run worklog:done` を実行して本日のログを完了記録
- 取り込み済みブランチ（develop を除く）をローカル・リモートから削除

## リスク評価

- 破壊的変更: なし
- 影響範囲: チャットカスタマイズとドキュメントのみ
- 運用影響: 実装手順の標準化による効率向上
